### PR TITLE
[REV-39] 설문, 질문 관련 엔티티 생성 

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -1,0 +1,50 @@
+package com.devcourse.ReviewRanger.question.domain;
+
+import com.devcourse.ReviewRanger.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "questions")
+public class Question extends BaseEntity {
+
+	@Column(nullable = false)
+	Long surveyId;
+
+	@Column(nullable = false)
+	@NotBlank(message = "질문제목은 빈값 일 수 없습니다.")
+	String title;
+
+	@Column(nullable = false)
+	QuestionType type;
+
+	@Column(nullable = false)
+	int sequence;
+
+	@Column(nullable = false)
+	boolean isRequired;
+
+	@Column(nullable = false)
+	boolean isDuplicated;
+
+	protected Question() {
+	}
+
+	public Question(String title, QuestionType type, String options, int sequence, boolean isRequired,
+		boolean isDuplicated) {
+		this.title = title;
+		this.type = type;
+		this.sequence = sequence;
+		this.isRequired = isRequired;
+		this.isDuplicated = isDuplicated;
+	}
+
+	public void assignSurveyId(Long surveyId) {
+		this.surveyId = surveyId;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -13,7 +13,7 @@ import lombok.Getter;
 @Table(name = "questions")
 public class Question extends BaseEntity {
 
-	@Column(nullable = false)
+	@Column(name = "survey_id", nullable = false)
 	Long surveyId;
 
 	@Column(nullable = false)
@@ -26,16 +26,16 @@ public class Question extends BaseEntity {
 	@Column(nullable = false)
 	int sequence;
 
-	@Column(nullable = false)
+	@Column(name = "is_required", nullable = false)
 	boolean isRequired;
 
-	@Column(nullable = false)
+	@Column(name = "is_duplicated", nullable = false)
 	boolean isDuplicated;
 
 	protected Question() {
 	}
 
-	public Question(String title, QuestionType type, String options, int sequence, boolean isRequired,
+	public Question(String title, QuestionType type, int sequence, boolean isRequired,
 		boolean isDuplicated) {
 		this.title = title;
 		this.type = type;

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -14,10 +15,12 @@ import lombok.Getter;
 public class Question extends BaseEntity {
 
 	@Column(name = "survey_id", nullable = false)
+	@NotBlank(message = "설문지 Id는 빈값 일 수 없습니다.")
 	Long surveyId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, length = 150)
 	@NotBlank(message = "질문제목은 빈값 일 수 없습니다.")
+	@Size(max = 150, message = "150자 이하로 입력하세요.")
 	String title;
 
 	@Column(nullable = false)

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -1,0 +1,30 @@
+package com.devcourse.ReviewRanger.question.domain;
+
+import com.devcourse.ReviewRanger.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "question_options")
+public class QuestionOption extends BaseEntity {
+
+	@Column(nullable = false)
+	Long questionId;
+
+	@Column(nullable = false)
+	@NotBlank(message = "옵션 내용은 빈값 일 수 없습니다.")
+	String optionContext;
+
+	protected QuestionOption() {
+	}
+
+	public QuestionOption(Long questionId, String optionContext) {
+		this.questionId = questionId;
+		this.optionContext = optionContext;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -14,10 +15,12 @@ import lombok.Getter;
 public class QuestionOption extends BaseEntity {
 
 	@Column(name = "question_id", nullable = false)
+	@NotBlank(message = "질문 Id는 빈값 일 수 없습니다.")
 	Long questionId;
 
-	@Column(name = "option_context", nullable = false)
+	@Column(name = "option_context", nullable = false, length = 100)
 	@NotBlank(message = "옵션 내용은 빈값 일 수 없습니다.")
+	@Size(max = 100, message = "150자 이하로 입력하세요.")
 	String optionContext;
 
 	protected QuestionOption() {

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -13,10 +13,10 @@ import lombok.Getter;
 @Table(name = "question_options")
 public class QuestionOption extends BaseEntity {
 
-	@Column(nullable = false)
+	@Column(name = "question_id", nullable = false)
 	Long questionId;
 
-	@Column(nullable = false)
+	@Column(name = "option_context", nullable = false)
 	@NotBlank(message = "옵션 내용은 빈값 일 수 없습니다.")
 	String optionContext;
 

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionType.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionType.java
@@ -1,0 +1,20 @@
+package com.devcourse.ReviewRanger.question.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum QuestionType {
+	SUBJECTIVE("주관식"),
+	OBJECTIVE_UNIQUE("객관식_중복없음"),
+	OBJECTIVE_DUPLICATE("객관식_중복있음"),
+	RATING("별점"),
+	DROPDOWN("드롭다운"),
+	HEXASTAT("육각스텟")
+	;
+
+	private final String displayName;
+
+	QuestionType(String displayName) {
+		this.displayName = displayName;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -11,6 +11,7 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter
@@ -19,12 +20,16 @@ import lombok.Getter;
 public class Survey extends BaseEntity {
 
 	@Column(name = "requester_id", nullable = false)
+	@NotBlank(message = "요청자 Id는 빈값 일 수 없습니다.")
 	Long requesterId;
 
-	@Column(nullable = false)
+	@Column(nullable = false, length = 50)
 	@NotBlank(message = "설문제목은 빈값 일 수 없습니다.")
+	@Size(max = 50, message = "50자 이하로 입력하세요.")
 	String title;
 
+	@Column(length = 100)
+	@Size(max = 100, message = "100자 이하로 입력하세요.")
 	String description;
 
 	@Column(nullable = false)

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -1,0 +1,44 @@
+package com.devcourse.ReviewRanger.survey.domain;
+
+import java.time.LocalDateTime;
+
+import com.devcourse.ReviewRanger.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "surveys")
+public class Survey extends BaseEntity {
+
+	@Column(nullable = false)
+	Long requesterId;
+
+	@Column(nullable = false)
+	@NotBlank(message = "설문제목은 빈값 일 수 없습니다.")
+	String title;
+
+	String description;
+
+	@Column(nullable = false)
+	SurveyType type;
+
+	LocalDateTime closedAt;
+
+	protected Survey() {
+	}
+
+	public Survey(String title, String description, SurveyType type) {
+		this.title = title;
+		this.description = description;
+		this.type = type;
+	}
+
+	public void assignSurveyId(Long requesterId) {
+		this.requesterId = requesterId;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -15,7 +15,7 @@ import lombok.Getter;
 @Table(name = "surveys")
 public class Survey extends BaseEntity {
 
-	@Column(nullable = false)
+	@Column(name = "requester_id", nullable = false)
 	Long requesterId;
 
 	@Column(nullable = false)
@@ -27,6 +27,7 @@ public class Survey extends BaseEntity {
 	@Column(nullable = false)
 	SurveyType type;
 
+	@Column(name = "closed_at", nullable = false)
 	LocalDateTime closedAt;
 
 	protected Survey() {

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -1,8 +1,11 @@
 package com.devcourse.ReviewRanger.survey.domain;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
+
 import java.time.LocalDateTime;
 
 import com.devcourse.ReviewRanger.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -28,6 +31,7 @@ public class Survey extends BaseEntity {
 	SurveyType type;
 
 	@Column(name = "closed_at", nullable = false)
+	@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	LocalDateTime closedAt;
 
 	protected Survey() {

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/SurveyType.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/SurveyType.java
@@ -1,0 +1,15 @@
+package com.devcourse.ReviewRanger.survey.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum SurveyType {
+	PEER_REVIEW("피어 리뷰")
+	;
+
+	private final String displayName;
+
+	SurveyType(String displayName) {
+		this.displayName = displayName;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/DeadlineStatus.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/DeadlineStatus.java
@@ -1,0 +1,16 @@
+package com.devcourse.ReviewRanger.surveyresult.domain;
+
+import lombok.Getter;
+
+@Getter
+public enum DeadlineStatus {
+	PROCEEDING("진행중"),
+	DEADLINE("제출"),
+	END("마감");
+
+	private final String displayName;
+
+	DeadlineStatus(String displayName) {
+		this.displayName = displayName;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/DeadlineStatus.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/DeadlineStatus.java
@@ -6,7 +6,8 @@ import lombok.Getter;
 public enum DeadlineStatus {
 	PROCEEDING("진행중"),
 	DEADLINE("제출"),
-	END("마감");
+	END("마감")
+	;
 
 	private final String displayName;
 

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
@@ -12,16 +12,16 @@ import lombok.Getter;
 @Table(name = "survey_results")
 public class SurveyResult extends BaseEntity {
 
-	@Column(nullable = false)
+	@Column(name = "survey_id", nullable = false)
 	private Long surveyId;
 
-	@Column(nullable = false)
+	@Column(name = "responser_id", nullable = false)
 	private Long responserId;
 
-	@Column(nullable = false)
+	@Column(name = "deadline_status", nullable = false)
 	private DeadlineStatus deadlineStatus;
 
-	@Column(nullable = false)
+	@Column(name = "question_answered_status", nullable = false)
 	private boolean questionAnsweredStatus;
 
 	protected SurveyResult() {

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
@@ -5,6 +5,7 @@ import com.devcourse.ReviewRanger.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
 
 @Getter
@@ -13,9 +14,11 @@ import lombok.Getter;
 public class SurveyResult extends BaseEntity {
 
 	@Column(name = "survey_id", nullable = false)
+	@NotBlank(message = "설문 Id는 빈값 일 수 없습니다.")
 	private Long surveyId;
 
 	@Column(name = "responser_id", nullable = false)
+	@NotBlank(message = "응답자 Id는 빈값 일 수 없습니다.")
 	private Long responserId;
 
 	@Column(name = "deadline_status", nullable = false)

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
@@ -1,0 +1,36 @@
+package com.devcourse.ReviewRanger.surveyresult.domain;
+
+import com.devcourse.ReviewRanger.BaseEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Entity
+@Table(name = "survey_results")
+public class SurveyResult extends BaseEntity {
+
+	@Column(nullable = false)
+	private Long surveyId;
+
+	@Column(nullable = false)
+	private Long responserId;
+
+	@Column(nullable = false)
+	private DeadlineStatus deadlineStatus;
+
+	@Column(nullable = false)
+	private boolean questionAnsweredStatus;
+
+	protected SurveyResult() {
+	}
+
+	public SurveyResult(Long surveyId, Long responserId) {
+		this.surveyId = surveyId;
+		this.responserId = responserId;
+		this.deadlineStatus = DeadlineStatus.PROCEEDING;
+		this.questionAnsweredStatus = false;
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 설문, 질문, 질문 유형, 설문 결과에 대한 엔티티를 추가했습니다.
- 논의한대로 모든 연관관계를 끊고, 외래키를 통해 연관될 수 있도록 했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 유효성 검사를 세세하게 하지 않았습니다. 논의되지 않은 상황에서 혼자 결정하는 것이 불필요했고 서비스 로직을 테스트해봐야 구체적으로 나올 것 같았습니다.