### PR TITLE
[REV-79] 질문 및 질문 옵션 생성 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
@@ -1,5 +1,6 @@
 package com.devcourse.ReviewRanger.question.application;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -26,15 +27,17 @@ public class QuestionService {
 
 	@Transactional
 	public List<Question> createQuestionInSurvey(Long surveyId, List<Question> questions) {
-		questions.forEach(question -> question.assignSurveyId(surveyId));
-		List<Question> createdQuestions = questionRepository.saveAll(questions);
+		List<Question> createdQuestions = new ArrayList<>();
 
 		for (Question question : questions) {
 			question.assignSurveyId(surveyId);
 			Question createdQuestion = questionRepository.save(question);
+			createdQuestions.add(createdQuestion);
 
-			if (question.isAnswerDuplicated()) {
-				createQuestionOptionsInQuestion(createdQuestion.getId(), question.createQuestionOptions());
+			if (question.getIsDuplicated()) {
+				Long questionId = createdQuestion.getId();
+				List<QuestionOption> questionOptions = question.createQuestionOptions();
+				createQuestionOptionsInQuestion(questionId, questionOptions);
 			}
 		}
 
@@ -48,5 +51,4 @@ public class QuestionService {
 
 		return createdQuestionOptions;
 	}
-
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
@@ -3,6 +3,7 @@ package com.devcourse.ReviewRanger.question.application;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.devcourse.ReviewRanger.question.domain.Question;
 import com.devcourse.ReviewRanger.question.domain.QuestionOption;
@@ -13,11 +14,13 @@ import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class QuestionService {
 
 	private final QuestionRepository questionRepository;
 	private final QuestionOptionRepository questionOptionRepository;
 
+	@Transactional
 	public List<Question> createQuestionInSurvey(Long surveyId, List<Question> questions) {
 		questions.forEach(question -> question.assignSurveyId(surveyId));
 		List<Question> createdQuestions = questionRepository.saveAll(questions);
@@ -34,6 +37,7 @@ public class QuestionService {
 		return createdQuestions;
 	}
 
+	@Transactional
 	public List<QuestionOption> createQuestionOptionsInQuestion(Long questionId, List<QuestionOption> questionOptions) {
 		questionOptions.forEach(question -> question.assignedQuestionId(questionId));
 		List<QuestionOption> createdQuestionOptions = questionOptionRepository.saveAll(questionOptions);

--- a/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
@@ -1,0 +1,44 @@
+package com.devcourse.ReviewRanger.question.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.question.domain.QuestionOption;
+import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
+import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class QuestionService {
+
+	private final QuestionRepository questionRepository;
+	private final QuestionOptionRepository questionOptionRepository;
+
+	public List<Question> createQuestionInSurvey(Long surveyId, List<Question> questions) {
+		questions.forEach(question -> question.assignSurveyId(surveyId));
+		List<Question> createdQuestions = questionRepository.saveAll(questions);
+
+		for (Question question : questions) {
+			question.assignSurveyId(surveyId);
+			Question createdQuestion = questionRepository.save(question);
+
+			if (question.isAnswerDuplicated()) {
+				createQuestionOptionsInQuestion(createdQuestion.getId(), question.createQuestionOptions());
+			}
+		}
+
+		return createdQuestions;
+	}
+
+	public List<QuestionOption> createQuestionOptionsInQuestion(Long questionId, List<QuestionOption> questionOptions) {
+		questionOptions.forEach(question -> question.assignedQuestionId(questionId));
+		List<QuestionOption> createdQuestionOptions = questionOptionRepository.saveAll(questionOptions);
+
+		return createdQuestionOptions;
+	}
+
+}

--- a/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
@@ -13,12 +13,16 @@ import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
 import lombok.RequiredArgsConstructor;
 
 @Service
-@RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class QuestionService {
 
 	private final QuestionRepository questionRepository;
 	private final QuestionOptionRepository questionOptionRepository;
+
+	public QuestionService(QuestionRepository questionRepository, QuestionOptionRepository questionOptionRepository) {
+		this.questionRepository = questionRepository;
+		this.questionOptionRepository = questionOptionRepository;
+	}
 
 	@Transactional
 	public List<Question> createQuestionInSurvey(Long surveyId, List<Question> questions) {

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -1,5 +1,8 @@
 package com.devcourse.ReviewRanger.question.domain;
 
+import java.util.Arrays;
+import java.util.List;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
 import jakarta.persistence.Column;
@@ -7,6 +10,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
+import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -38,11 +42,14 @@ public class Question extends BaseEntity {
 	@Column(name = "is_duplicated", nullable = false)
 	private Boolean isDuplicated;
 
+	@Transient
+	String options;
+
 	protected Question() {
 	}
 
-	public Question(String title, QuestionType type, int sequence, boolean isRequired,
-		boolean isDuplicated) {
+	public Question(String title, QuestionType type, Integer sequence, Boolean isRequired,
+		boolean isDuplicated, String options) {
 		this.title = title;
 		this.type = type;
 		this.sequence = sequence;
@@ -52,5 +59,15 @@ public class Question extends BaseEntity {
 
 	public void assignSurveyId(Long surveyId) {
 		this.surveyId = surveyId;
+	}
+
+	public boolean isAnswerDuplicated() {
+		return this.isDuplicated;
+	}
+
+	public List<QuestionOption> createQuestionOptions() {
+		return Arrays.stream(options.split(","))
+			.map(optionContext -> new QuestionOption(optionContext))
+			.toList();
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -61,10 +61,6 @@ public class Question extends BaseEntity {
 		this.surveyId = surveyId;
 	}
 
-	public boolean isAnswerDuplicated() {
-		return this.isDuplicated;
-	}
-
 	public List<QuestionOption> createQuestionOptions() {
 		return Arrays.stream(options.split(","))
 			.map(optionContext -> new QuestionOption(optionContext))

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -43,7 +43,7 @@ public class Question extends BaseEntity {
 	private Boolean isDuplicated;
 
 	@Transient
-	String options;
+	private String options;
 
 	protected Question() {
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -4,6 +4,8 @@ import com.devcourse.ReviewRanger.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -16,24 +18,25 @@ public class Question extends BaseEntity {
 
 	@Column(name = "survey_id", nullable = false)
 	@NotBlank(message = "설문지 Id는 빈값 일 수 없습니다.")
-	Long surveyId;
+	private Long surveyId;
 
 	@Column(nullable = false, length = 150)
 	@NotBlank(message = "질문제목은 빈값 일 수 없습니다.")
 	@Size(max = 150, message = "150자 이하로 입력하세요.")
-	String title;
+	private String title;
 
 	@Column(nullable = false)
-	QuestionType type;
+	@Enumerated(EnumType.STRING)
+	private QuestionType type;
 
 	@Column(nullable = false)
-	int sequence;
+	private Integer sequence;
 
 	@Column(name = "is_required", nullable = false)
-	boolean isRequired;
+	private Boolean isRequired;
 
 	@Column(name = "is_duplicated", nullable = false)
-	boolean isDuplicated;
+	private Boolean isDuplicated;
 
 	protected Question() {
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -16,12 +16,12 @@ public class QuestionOption extends BaseEntity {
 
 	@Column(name = "question_id", nullable = false)
 	@NotBlank(message = "질문 Id는 빈값 일 수 없습니다.")
-	Long questionId;
+	private Long questionId;
 
 	@Column(name = "option_context", nullable = false, length = 100)
 	@NotBlank(message = "옵션 내용은 빈값 일 수 없습니다.")
 	@Size(max = 100, message = "150자 이하로 입력하세요.")
-	String optionContext;
+	private String optionContext;
 
 	protected QuestionOption() {
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -26,8 +26,11 @@ public class QuestionOption extends BaseEntity {
 	protected QuestionOption() {
 	}
 
-	public QuestionOption(Long questionId, String optionContext) {
-		this.questionId = questionId;
+	public QuestionOption(String optionContext) {
 		this.optionContext = optionContext;
+	}
+
+	public void assignedQuestionId(Long questionId) {
+		this.questionId = questionId;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionOptionRepository.java
@@ -1,0 +1,10 @@
+package com.devcourse.ReviewRanger.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.devcourse.ReviewRanger.question.domain.QuestionOption;
+
+@Repository
+public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionOptionRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionOptionRepository.java
@@ -5,6 +5,5 @@ import org.springframework.stereotype.Repository;
 
 import com.devcourse.ReviewRanger.question.domain.QuestionOption;
 
-@Repository
 public interface QuestionOptionRepository extends JpaRepository<QuestionOption, Long> {
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionRepository.java
@@ -1,0 +1,10 @@
+package com.devcourse.ReviewRanger.question.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+
+@Repository
+public interface QuestionRepository extends JpaRepository<Question, Long> {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/repository/QuestionRepository.java
@@ -5,6 +5,5 @@ import org.springframework.stereotype.Repository;
 
 import com.devcourse.ReviewRanger.question.domain.Question;
 
-@Repository
 public interface QuestionRepository extends JpaRepository<Question, Long> {
 }

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -21,23 +23,24 @@ public class Survey extends BaseEntity {
 
 	@Column(name = "requester_id", nullable = false)
 	@NotBlank(message = "요청자 Id는 빈값 일 수 없습니다.")
-	Long requesterId;
+	private Long requesterId;
 
 	@Column(nullable = false, length = 50)
 	@NotBlank(message = "설문제목은 빈값 일 수 없습니다.")
 	@Size(max = 50, message = "50자 이하로 입력하세요.")
-	String title;
+	private String title;
 
 	@Column(length = 100)
 	@Size(max = 100, message = "100자 이하로 입력하세요.")
-	String description;
+	private String description;
 
 	@Column(nullable = false)
-	SurveyType type;
+	@Enumerated(EnumType.STRING)
+	private SurveyType type;
 
 	@Column(name = "closed_at", nullable = false)
 	@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
-	LocalDateTime closedAt;
+	private LocalDateTime closedAt;
 
 	protected Survey() {
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
@@ -4,6 +4,8 @@ import com.devcourse.ReviewRanger.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Getter;
@@ -22,10 +24,11 @@ public class SurveyResult extends BaseEntity {
 	private Long responserId;
 
 	@Column(name = "deadline_status", nullable = false)
+	@Enumerated(EnumType.STRING)
 	private DeadlineStatus deadlineStatus;
 
 	@Column(name = "question_answered_status", nullable = false)
-	private boolean questionAnsweredStatus;
+	private Boolean questionAnsweredStatus;
 
 	protected SurveyResult() {
 	}

--- a/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
@@ -1,0 +1,80 @@
+package com.devcourse.ReviewRanger.question.application;
+
+import static com.devcourse.ReviewRanger.question.domain.QuestionType.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.question.domain.QuestionOption;
+import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
+import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
+
+@ExtendWith(MockitoExtension.class)
+class QuestionServiceTest {
+
+	@InjectMocks
+	private QuestionService questionService;
+
+	@Mock
+	private QuestionRepository questionRepository;
+
+	@Mock
+	private QuestionOptionRepository questionOptionRepository;
+
+	@Test
+	public void 옵션이_없는_설문의_질문_생성_성공() {
+		// given
+		Long surveyId = 1L;
+		List<Question> questions = List.of(
+			new Question(
+				"question1",
+				SUBJECTIVE,
+				1,
+				true,
+				false,
+				null
+			)
+		);
+		when(questionRepository.saveAll(questions)).thenReturn(questions);
+
+		// when
+		List<Question> createdQuestions = questionService.createQuestionInSurvey(surveyId, questions);
+
+		// then
+		verify(questionRepository).saveAll(questions);
+		assertEquals(questions, createdQuestions);
+	}
+
+	@Test
+	public void 옵션이_있는_설문의_질문_생성_성공() {
+		// given
+		Long questionId = 1L;
+		List<QuestionOption> questionOptions = List.of(
+			new QuestionOption(
+				"optionContext"
+			),
+			new QuestionOption(
+				"optionContext2"
+			)
+		);
+
+		when(questionOptionRepository.saveAll(questionOptions)).thenReturn(questionOptions);
+
+		// when
+		List<QuestionOption> createdQuestionOptions = questionService.createQuestionOptionsInQuestion(questionId,
+			questionOptions);
+
+		// then
+		verify(questionOptionRepository).saveAll(questionOptions);
+		assertEquals(questionOptions, createdQuestionOptions);
+	}
+
+}

--- a/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
@@ -1,6 +1,5 @@
 package com.devcourse.ReviewRanger.question.application;
 
-import static com.devcourse.ReviewRanger.question.domain.QuestionType.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -12,7 +11,6 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.devcourse.ReviewRanger.question.domain.Question;
 import com.devcourse.ReviewRanger.question.domain.QuestionOption;
 import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
 import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
@@ -28,30 +26,6 @@ class QuestionServiceTest {
 
 	@Mock
 	private QuestionOptionRepository questionOptionRepository;
-
-	@Test
-	public void 옵션이_없는_설문의_질문_생성_성공() {
-		// given
-		Long surveyId = 1L;
-		List<Question> questions = List.of(
-			new Question(
-				"question1",
-				SUBJECTIVE,
-				1,
-				true,
-				false,
-				null
-			)
-		);
-		when(questionRepository.saveAll(questions)).thenReturn(questions);
-
-		// when
-		List<Question> createdQuestions = questionService.createQuestionInSurvey(surveyId, questions);
-
-		// then
-		verify(questionRepository).saveAll(questions);
-		assertEquals(questions, createdQuestions);
-	}
 
 	@Test
 	public void 옵션이_있는_설문의_질문_생성_성공() {


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 설문 생성시 만들어지는 질문, 질문 옵션에 대한 기능을 구현했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 설문 생성 기능이 큰 작업이다보니 이에 속하는 질문과 질문 옵션 기능을 먼저 구현했습니다.
- api가 설문에 포함되다보니, 이에 따라 추후 수정이 있을 것 같습니다.

- 연관관계를 끊은 상태에서 설문, 질문, 질문 옵션 3단계의 데이터를 받는 과정이 복잡합니다. 
  우선 "질문" 엔티티 필드에 디비에 컬럼이 생기지 않도록 options 필드를 생성했습니다. 
  여기서 컴마를 통해 옵션값을 구분하고 엔티티 내부에서 questionOptions를 만들어 줍니다.

- 위의 부분은 설문 생성 api가 만들어 질 때 같이 수정될 것 같습니다. 이떄 연관관계도 맺을까 생각중입니다.
  해당 부분을 잘 봐주시고 좋은 의견 주시면 좋겠습니다.


### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 질문 생성, 질문 옵션 생성에 대해 메서드가 실행되는지를 테스트 했다.
