### PR TITLE
[REV-108] 유저 회원가입, 이름/이메일 검증 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
@@ -1,12 +1,19 @@
 package com.devcourse.ReviewRanger.common.config;
 
+import static org.springframework.security.config.Customizer.*;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
 
 import com.devcourse.ReviewRanger.common.jwt.JwtProvider;
+
+import jakarta.servlet.DispatcherType;
 
 @EnableWebSecurity
 @Configuration
@@ -24,4 +31,25 @@ public class SecurityConfig {
 		return new BCryptPasswordEncoder();
 	}
 
+	@Bean
+	public WebSecurityCustomizer webSecurityCustomizer() {
+		return (web) -> web.ignoring().requestMatchers(permitUrls);
+	}
+
+	@Bean
+	public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+		http.csrf().disable().cors().disable()
+			.authorizeHttpRequests(request -> request
+					.dispatcherTypeMatchers(DispatcherType.FORWARD).permitAll()
+					.anyRequest().permitAll()
+				// .anyRequest().authenticated()
+			)
+			// .formLogin(login -> login    // form 방식 로그인 사용
+			// 	.defaultSuccessUrl("/view/dashboard", true)    // 성공 시 dashboard로
+			// 	.permitAll()    // 대시보드 이동이 막히면 안되므로 얘는 허용
+			// )
+			.logout(withDefaults());
+
+		return http.build();
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -1,0 +1,17 @@
+package com.devcourse.ReviewRanger.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public enum ErrorCode {
+
+	EXIST_SAME_ID("이미 사용중인 아이디 입니다."),
+	EXIST_SAME_EMAIL("이미 사용중인 이메일 입니다."),
+	NOT_SAME_PASSWORD("동일한 비밀번호를 입력");
+
+	private final String message;
+
+	ErrorCode(String message) {
+		this.message = message;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -5,9 +5,8 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-	EXIST_SAME_ID("이미 사용중인 아이디 입니다."),
-	EXIST_SAME_EMAIL("이미 사용중인 이메일 입니다."),
-	NOT_SAME_PASSWORD("동일한 비밀번호를 입력");
+	EXIST_SAME_NAME("이미 사용중인 이름 입니다."),
+	EXIST_SAME_EMAIL("이미 사용중인 이메일 입니다.");
 
 	private final String message;
 

--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/RangerException.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/RangerException.java
@@ -1,0 +1,11 @@
+package com.devcourse.ReviewRanger.common.exception;
+
+public class RangerException extends RuntimeException {
+
+	private final ErrorCode errorCode;
+
+	public RangerException(ErrorCode errorCode) {
+		super(errorCode.getMessage());
+		this.errorCode = errorCode;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
@@ -1,0 +1,37 @@
+package com.devcourse.ReviewRanger.user.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devcourse.ReviewRanger.user.dto.JoinRequest;
+import com.devcourse.ReviewRanger.user.dto.ValidateEmailRequest;
+import com.devcourse.ReviewRanger.user.dto.ValidateNameRequest;
+import com.devcourse.ReviewRanger.user.service.UserService;
+
+import jakarta.validation.Valid;
+
+@RestController
+public class UserController {
+
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	@PostMapping("/sign-up")
+	public Boolean join(@RequestBody @Valid JoinRequest request) {
+		return userService.join(request);
+	}
+
+	@PostMapping("/members/check-name")
+	public Boolean checkname(@RequestBody @Valid ValidateNameRequest request) {
+		return !userService.checkName(request.name());
+	}
+
+	@PostMapping("/members/check-email")
+	public Boolean checkEmail(@RequestBody @Valid ValidateEmailRequest request) {
+		return !userService.checkEmail(request.email());
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
@@ -27,11 +27,11 @@ public class UserController {
 
 	@PostMapping("/members/check-name")
 	public Boolean checkname(@RequestBody @Valid ValidateNameRequest request) {
-		return !userService.checkName(request.name());
+		return userService.isNotExistName(request.name());
 	}
 
 	@PostMapping("/members/check-email")
 	public Boolean checkEmail(@RequestBody @Valid ValidateEmailRequest request) {
-		return !userService.checkEmail(request.email());
+		return userService.isNotExistEmail(request.email());
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/user/domain/User.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/domain/User.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user;
+package com.devcourse.ReviewRanger.user.domain;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 
@@ -28,7 +28,6 @@ public class User extends BaseEntity {
 
 	@Column(nullable = false)
 	@NotBlank(message = "비밀번호는 빈값 일 수 없습니다.")
-	@Pattern(regexp = PASSWORD_REGEXP, message = "비밀번호 형식이 맞지 않습니다.")
 	private String password;
 
 	protected User() {

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/JoinRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/JoinRequest.java
@@ -1,0 +1,30 @@
+package com.devcourse.ReviewRanger.user.dto;
+
+import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
+
+import com.devcourse.ReviewRanger.user.domain.User;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record JoinRequest(
+	@Column(nullable = false, length = 20)
+	@NotBlank(message = "이름은 빈값 일 수 없습니다.")
+	@Pattern(regexp = NAME_REGEXP, message = "이름 형식이 맞지 않습니다.")
+	String name,
+
+	@Column(nullable = false, length = 30)
+	@NotBlank(message = "이메일은 빈값 일 수 없습니다.")
+	@Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식이 맞지 않습니다.")
+	String email,
+
+	@Column(nullable = false)
+	@NotBlank(message = "비밀번호는 빈값 일 수 없습니다.")
+	@Pattern(regexp = PASSWORD_REGEXP, message = "비밀번호 형식이 맞지 않습니다.")
+	String password
+) {
+	public User toEntity(String password) {
+		return new User(this.name, this.email, password);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateEmailRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateEmailRequest.java
@@ -1,0 +1,15 @@
+package com.devcourse.ReviewRanger.user.dto;
+
+import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ValidateEmailRequest(
+	@Column(nullable = false, length = 30)
+	@NotBlank(message = "이메일은 빈값 일 수 없습니다.")
+	@Pattern(regexp = EMAIL_REGEXP, message = "이메일 형식이 맞지 않습니다.")
+	String email
+) {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateNameRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateNameRequest.java
@@ -1,0 +1,15 @@
+package com.devcourse.ReviewRanger.user.dto;
+
+import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
+
+import jakarta.persistence.Column;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ValidateNameRequest(
+	@Column(nullable = false, length = 20)
+	@NotBlank(message = "이름은 빈값 일 수 없습니다.")
+	@Pattern(regexp = NAME_REGEXP, message = "이름 형식이 맞지 않습니다.")
+	String name
+) {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/repository/UserRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/repository/UserRepository.java
@@ -1,0 +1,11 @@
+package com.devcourse.ReviewRanger.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.devcourse.ReviewRanger.user.domain.User;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+	Boolean existsByEmail(String email);
+
+	Boolean existsByName(String name);
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
@@ -1,0 +1,49 @@
+package com.devcourse.ReviewRanger.user.service;
+
+import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
+
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.common.exception.RangerException;
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.devcourse.ReviewRanger.user.dto.JoinRequest;
+import com.devcourse.ReviewRanger.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class UserService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+
+	public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+		this.userRepository = userRepository;
+		this.passwordEncoder = passwordEncoder;
+	}
+
+	@Transactional
+	public Boolean join(JoinRequest request) {
+		String encodedPassword = passwordEncoder.encode(request.password());
+		User newUser = request.toEntity(encodedPassword);
+
+		if (checkName(request.name())) {
+			throw new RangerException(EXIST_SAME_ID);
+		}
+
+		if (checkEmail(request.email())) {
+			throw new RangerException(EXIST_SAME_EMAIL);
+		}
+
+		return (userRepository.save(newUser).getId()) > 0;
+	}
+
+	public boolean checkName(String name) {
+		return userRepository.existsByName(name);
+	}
+
+	public boolean checkEmail(String email) {
+		return userRepository.existsByEmail(email);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
@@ -28,22 +28,22 @@ public class UserService {
 		String encodedPassword = passwordEncoder.encode(request.password());
 		User newUser = request.toEntity(encodedPassword);
 
-		if (checkName(request.name())) {
+		if (!isNotExistName(request.name())) {
 			throw new RangerException(EXIST_SAME_NAME);
 		}
 
-		if (checkEmail(request.email())) {
+		if (!isNotExistEmail(request.email())) {
 			throw new RangerException(EXIST_SAME_EMAIL);
 		}
 
 		return (userRepository.save(newUser).getId()) > 0;
 	}
 
-	public boolean checkName(String name) {
-		return userRepository.existsByName(name);
+	public boolean isNotExistName(String name) {
+		return !userRepository.existsByName(name);
 	}
 
-	public boolean checkEmail(String email) {
-		return userRepository.existsByEmail(email);
+	public boolean isNotExistEmail(String email) {
+		return !userRepository.existsByEmail(email);
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/service/UserService.java
@@ -29,7 +29,7 @@ public class UserService {
 		User newUser = request.toEntity(encodedPassword);
 
 		if (checkName(request.name())) {
-			throw new RangerException(EXIST_SAME_ID);
+			throw new RangerException(EXIST_SAME_NAME);
 		}
 
 		if (checkEmail(request.email())) {

--- a/src/test/java/com/devcourse/ReviewRanger/user/service/UserFixture.java
+++ b/src/test/java/com/devcourse/ReviewRanger/user/service/UserFixture.java
@@ -1,0 +1,27 @@
+package com.devcourse.ReviewRanger.user.service;
+
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.devcourse.ReviewRanger.user.dto.JoinRequest;
+
+public enum UserFixture {
+
+	SUYEON_FIXTURE("장수연", "dev1234@devcource.com", "abc12341234");
+
+	private final String name;
+	private final String email;
+	private final String password;
+
+	UserFixture(String name, String email, String password) {
+		this.name = name;
+		this.email = email;
+		this.password = password;
+	}
+
+	public User toEntity() {
+		return new User(name, email, password);
+	}
+
+	public JoinRequest toJoinRequest() {
+		return new JoinRequest(name, email, password);
+	}
+}

--- a/src/test/java/com/devcourse/ReviewRanger/user/service/UserServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/user/service/UserServiceTest.java
@@ -1,0 +1,35 @@
+package com.devcourse.ReviewRanger.user.service;
+
+import static com.devcourse.ReviewRanger.user.service.UserFixture.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.user.dto.JoinRequest;
+
+@Transactional
+@SpringBootTest
+class UserServiceTest {
+
+	private final UserService userService;
+
+	@Autowired
+	public UserServiceTest(UserService userService) {
+		this.userService = userService;
+	}
+
+	@Test
+	void 회원가입_테스트_성공() {
+		// given
+		JoinRequest joinRequest = SUYEON_FIXTURE.toJoinRequest();
+
+		// when
+		Boolean joinResult = userService.join(joinRequest);
+
+		// then
+		assertTrue(joinResult);
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 유저 회원가입, 이름/이메일 검증 추가
- User Fixture Instance를 구현하여 테스트 코드 재사용성 증가

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- User Entity의 password에 걸리는 유효성 검증은 암호화된 비밀번호가 들어오는 상황에 적합하지 않다고 판단해 제거 하였습니다.
- 현재 security 권한을 전부 허용하여 api 테스트가 가능하도록 수정하였습니다.


### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 유저 회원가입 통합 테스트 진행했습니다. mockito는 시간이 너무 오래걸려서 .. 추후에 추가하도록 하겠습니다