### PR TITLE
[REV-78] 설문 생성 기능 구현 

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/application/QuestionService.java
@@ -1,6 +1,5 @@
 package com.devcourse.ReviewRanger.question.application;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -10,8 +9,6 @@ import com.devcourse.ReviewRanger.question.domain.Question;
 import com.devcourse.ReviewRanger.question.domain.QuestionOption;
 import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
 import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
-
-import lombok.RequiredArgsConstructor;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,29 +23,22 @@ public class QuestionService {
 	}
 
 	@Transactional
-	public List<Question> createQuestionInSurvey(Long surveyId, List<Question> questions) {
-		List<Question> createdQuestions = new ArrayList<>();
+	public void createQuestionInSurvey(Long surveyId, List<Question> questions) {
+		questions.forEach(question -> question.assignSurveyId(surveyId));
+		List<Question> createdQuestion = questionRepository.saveAll(questions);
 
-		for (Question question : questions) {
-			question.assignSurveyId(surveyId);
-			Question createdQuestion = questionRepository.save(question);
-			createdQuestions.add(createdQuestion);
-
+		for (Question question : createdQuestion) {
 			if (question.getIsDuplicated()) {
-				Long questionId = createdQuestion.getId();
-				List<QuestionOption> questionOptions = question.createQuestionOptions();
-				createQuestionOptionsInQuestion(questionId, questionOptions);
+				List<QuestionOption> questionOptions = question.getQuestionOptions();
+				createQuestionOptionsInQuestion(question, questionOptions);
 			}
 		}
-
-		return createdQuestions;
 	}
 
 	@Transactional
-	public List<QuestionOption> createQuestionOptionsInQuestion(Long questionId, List<QuestionOption> questionOptions) {
-		questionOptions.forEach(question -> question.assignedQuestionId(questionId));
+	public void createQuestionOptionsInQuestion(Question question,
+		List<QuestionOption> questionOptions) {
+		questionOptions.forEach(questionOption -> questionOption.setQuestion(question));
 		List<QuestionOption> createdQuestionOptions = questionOptionRepository.saveAll(questionOptions);
-
-		return createdQuestionOptions;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -21,7 +21,6 @@ import lombok.Getter;
 public class Question extends BaseEntity {
 
 	@Column(name = "survey_id", nullable = false)
-	@NotBlank(message = "설문지 Id는 빈값 일 수 없습니다.")
 	private Long surveyId;
 
 	@Column(nullable = false, length = 150)

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -1,6 +1,6 @@
 package com.devcourse.ReviewRanger.question.domain;
 
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 
 import com.devcourse.ReviewRanger.BaseEntity;
@@ -9,8 +9,8 @@ import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.Getter;
@@ -42,28 +42,24 @@ public class Question extends BaseEntity {
 	@Column(name = "is_duplicated", nullable = false)
 	private Boolean isDuplicated;
 
-	@Transient
-	private String options;
+	@OneToMany(mappedBy = "question")
+	private List<QuestionOption> questionOptions = new ArrayList<>();
 
 	protected Question() {
 	}
 
-	public Question(String title, QuestionType type, Integer sequence, Boolean isRequired,
-		boolean isDuplicated, String options) {
+	public Question(String title, QuestionType type, Integer sequence, Boolean isRequired, boolean isDuplicated,
+		List<QuestionOption> questionOptions) {
 		this.title = title;
 		this.type = type;
 		this.sequence = sequence;
 		this.isRequired = isRequired;
 		this.isDuplicated = isDuplicated;
+		this.questionOptions = questionOptions;
 	}
 
 	public void assignSurveyId(Long surveyId) {
 		this.surveyId = surveyId;
 	}
 
-	public List<QuestionOption> createQuestionOptions() {
-		return Arrays.stream(options.split(","))
-			.map(optionContext -> new QuestionOption(optionContext))
-			.toList();
-	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -32,4 +32,7 @@ public class QuestionOption extends BaseEntity {
 		this.optionContext = optionContext;
 	}
 
+	public void setQuestion(Question question) {
+		this.question = question;
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -4,6 +4,8 @@ import com.devcourse.ReviewRanger.BaseEntity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
@@ -14,9 +16,9 @@ import lombok.Getter;
 @Table(name = "question_options")
 public class QuestionOption extends BaseEntity {
 
-	@Column(name = "question_id", nullable = false)
-	@NotBlank(message = "질문 Id는 빈값 일 수 없습니다.")
-	private Long questionId;
+	@ManyToOne
+	@JoinColumn(name = "question_id")
+	private Question question;
 
 	@Column(name = "option_context", nullable = false, length = 100)
 	@NotBlank(message = "옵션 내용은 빈값 일 수 없습니다.")
@@ -30,7 +32,4 @@ public class QuestionOption extends BaseEntity {
 		this.optionContext = optionContext;
 	}
 
-	public void assignedQuestionId(Long questionId) {
-		this.questionId = questionId;
-	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/survey/api/SurveyController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/api/SurveyController.java
@@ -2,6 +2,8 @@ package com.devcourse.ReviewRanger.survey.api;
 
 import java.util.List;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,13 +23,12 @@ public class SurveyController {
 	}
 
 	@PostMapping("/surveys")
-	public String createSurvey(@RequestBody CreateSurveyRequest createSurveyRequest) {
-
+	public ResponseEntity<Boolean> createSurvey(@RequestBody CreateSurveyRequest createSurveyRequest) {
 		Survey survey = createSurveyRequest.toSurvey();
+		survey.assignRequesterId(1L);
 		List<Question> questions = createSurveyRequest.toQuestions();
+		Boolean result = surveyService.createSurvey(survey, questions);
 
-		surveyService.createSurvey(survey, questions);
-		return "";
+		return new ResponseEntity<Boolean>(result, HttpStatus.CREATED);
 	}
-
 }

--- a/src/main/java/com/devcourse/ReviewRanger/survey/api/SurveyController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/api/SurveyController.java
@@ -1,0 +1,33 @@
+package com.devcourse.ReviewRanger.survey.api;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.survey.application.SurveyService;
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+import com.devcourse.ReviewRanger.survey.dto.request.CreateSurveyRequest;
+
+@RestController
+public class SurveyController {
+
+	private final SurveyService surveyService;
+
+	public SurveyController(SurveyService surveyService) {
+		this.surveyService = surveyService;
+	}
+
+	@PostMapping("/surveys")
+	public String createSurvey(@RequestBody CreateSurveyRequest createSurveyRequest) {
+
+		Survey survey = createSurveyRequest.toSurvey();
+		List<Question> questions = createSurveyRequest.toQuestions();
+
+		surveyService.createSurvey(survey, questions);
+		return "";
+	}
+
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/application/SurveyService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/application/SurveyService.java
@@ -1,0 +1,33 @@
+package com.devcourse.ReviewRanger.survey.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.question.application.QuestionService;
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+import com.devcourse.ReviewRanger.survey.repository.SurveyRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class SurveyService {
+
+	private final QuestionService questionService;
+
+	private final SurveyRepository surveyRepository;
+
+	public SurveyService(QuestionService questionService, SurveyRepository surveyRepository) {
+		this.questionService = questionService;
+		this.surveyRepository = surveyRepository;
+	}
+
+	@Transactional
+	public boolean createSurvey(Survey survey, List<Question> questions) {
+		Survey save = surveyRepository.save(survey);
+		questionService.createQuestionInSurvey(save.getId(), questions);
+		
+		return true;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -22,7 +22,6 @@ import lombok.Getter;
 public class Survey extends BaseEntity {
 
 	@Column(name = "requester_id", nullable = false)
-	@NotBlank(message = "요청자 Id는 빈값 일 수 없습니다.")
 	private Long requesterId;
 
 	@Column(nullable = false, length = 50)
@@ -45,13 +44,14 @@ public class Survey extends BaseEntity {
 	protected Survey() {
 	}
 
-	public Survey(String title, String description, SurveyType type) {
+	public Survey(String title, String description, SurveyType type, LocalDateTime closedAt) {
 		this.title = title;
 		this.description = description;
 		this.type = type;
+		this.closedAt = closedAt;
 	}
 
-	public void assignSurveyId(Long requesterId) {
+	public void assignRequesterId(Long requesterId) {
 		this.requesterId = requesterId;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/QuestionDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/QuestionDto.java
@@ -1,0 +1,27 @@
+package com.devcourse.ReviewRanger.survey.dto;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.question.domain.QuestionOption;
+import com.devcourse.ReviewRanger.question.domain.QuestionType;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record QuestionDto(
+	String title,
+	QuestionType type,
+	@JsonProperty("questionOptions") List<QuestionOptionDto> questionOptionDtos,
+	Integer sequence,
+	Boolean isDuplicated,
+	Boolean isRequired
+) {
+
+	public Question toEntity() {
+		List<QuestionOption> questionOptions = isDuplicated
+			? questionOptionDtos.stream().map(QuestionOptionDto::toEntity).toList()
+			: new ArrayList<>();
+
+		return new Question(title, type, sequence, isRequired, isDuplicated, questionOptions);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/QuestionOptionDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/QuestionOptionDto.java
@@ -1,0 +1,10 @@
+package com.devcourse.ReviewRanger.survey.dto;
+
+import com.devcourse.ReviewRanger.question.domain.QuestionOption;
+
+public record QuestionOptionDto(String optionContext) {
+
+	public QuestionOption toEntity() {
+		return new QuestionOption(optionContext);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/SurveyDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/SurveyDto.java
@@ -1,12 +1,14 @@
 package com.devcourse.ReviewRanger.survey.dto;
 
+import java.time.LocalDateTime;
+
 import com.devcourse.ReviewRanger.survey.domain.Survey;
 import com.devcourse.ReviewRanger.survey.domain.SurveyType;
 
-public record SurveyDto(String title, String description, SurveyType surveyType) {
+public record SurveyDto(String title, String description, SurveyType surveyType, LocalDateTime closedAt) {
 
 	public Survey toEntity() {
-		return new Survey(title, description, surveyType);
+		return new Survey(title, description, surveyType, closedAt);
 	}
 }
 

--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/SurveyDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/SurveyDto.java
@@ -1,0 +1,12 @@
+package com.devcourse.ReviewRanger.survey.dto;
+
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+import com.devcourse.ReviewRanger.survey.domain.SurveyType;
+
+public record SurveyDto(String title, String description, SurveyType surveyType) {
+
+	public Survey toEntity() {
+		return new Survey(title, description, surveyType);
+	}
+}
+

--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/request/CreateSurveyRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/request/CreateSurveyRequest.java
@@ -1,0 +1,23 @@
+package com.devcourse.ReviewRanger.survey.dto.request;
+
+import java.util.List;
+
+import com.devcourse.ReviewRanger.question.domain.Question;
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+import com.devcourse.ReviewRanger.survey.dto.QuestionDto;
+import com.devcourse.ReviewRanger.survey.dto.SurveyDto;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public record CreateSurveyRequest(
+	@JsonProperty("survey") SurveyDto surveyDto,
+	@JsonProperty("questions") List<QuestionDto> questionDtos
+) {
+
+	public Survey toSurvey() {
+		return surveyDto.toEntity();
+	}
+
+	public List<Question> toQuestions() {
+		return questionDtos.stream().map(questionDto -> questionDto.toEntity()).toList();
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/survey/repository/SurveyRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/repository/SurveyRepository.java
@@ -1,0 +1,8 @@
+package com.devcourse.ReviewRanger.survey.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+
+public interface SurveyRepository extends JpaRepository<Survey, Long> {
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 설문 생성시 질문, 질문 옵션이 함께 저장되는 기능을 구현했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 엔티티에 대응하는 디티오와 request dto를 별도로 구현해서 계층구조를 만들었습니다.
- 질문과 질문 옵션은 연관관계를 맺지 않고는 너무 지저분해져서 양방향으로 맺어두었습니다. 테이블 동일하고 큰 영향을 주지 않습니다.
- 이에 따라 기존 질문, 질문옵션 생성 기능도 수정했습니다.
- 디티오 엔티티 변환시 외래키 필드에 대한 유효성검사 떄문에 예외가 발생했습니다. 따라서 우선 제거 해두었습니다. 연관관계 맺으면서 해당 조건을 다시 걸어주면 될 것 같습니다. 

- 여기까지 pr이 클 것 같네요!! 많이 줄여보겠습니다.

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 테스트코드
