### PR TITLE
[REV-00] 스프링부트 버전 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.1.5'
+    id 'org.springframework.boot' version '2.7.17'
     id 'io.spring.dependency-management' version '1.1.3'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:0.11.5"
 
     //swagger
-    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
+    //implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/devcourse/ReviewRanger/BaseEntity.java
+++ b/src/main/java/com/devcourse/ReviewRanger/BaseEntity.java
@@ -4,18 +4,20 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
 
 import java.time.LocalDateTime;
 
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.MappedSuperclass;
+
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.EntityListeners;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.MappedSuperclass;
+
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/afterresult/domain/AfterResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/afterresult/domain/AfterResponse.java
@@ -1,16 +1,16 @@
 package com.devcourse.ReviewRanger.afterresult.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 import com.devcourse.ReviewRanger.question.domain.QuestionType;
-
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 
 @Entity
 @Table(name = "after_responses")

--- a/src/main/java/com/devcourse/ReviewRanger/afterresult/domain/AfterResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/afterresult/domain/AfterResult.java
@@ -1,12 +1,12 @@
 package com.devcourse.ReviewRanger.afterresult.domain;
 
-import com.devcourse.ReviewRanger.BaseEntity;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
+import com.devcourse.ReviewRanger.BaseEntity;
 
 @Entity
 @Table(name = "after_results")

--- a/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
@@ -2,6 +2,8 @@ package com.devcourse.ReviewRanger.common.config;
 
 import static org.springframework.security.config.Customizer.*;
 
+import javax.servlet.DispatcherType;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -12,8 +14,6 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import com.devcourse.ReviewRanger.common.jwt.JwtProvider;
-
-import jakarta.servlet.DispatcherType;
 
 @EnableWebSecurity
 @Configuration
@@ -33,7 +33,7 @@ public class SecurityConfig {
 
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
-		return (web) -> web.ignoring().requestMatchers(permitUrls);
+		return (web) -> web.ignoring().requestMatchers();
 	}
 
 	@Bean

--- a/src/main/java/com/devcourse/ReviewRanger/common/config/SwaggerConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/SwaggerConfig.java
@@ -1,46 +1,46 @@
-package com.devcourse.ReviewRanger.common.config;
-
-import org.springdoc.core.models.GroupedOpenApi;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
-
-import io.swagger.v3.oas.annotations.OpenAPIDefinition;
-import io.swagger.v3.oas.annotations.info.Info;
-
-@OpenAPIDefinition(
-	info = @Info(title = "리뷰레인저 서비스",
-		description = "리뷰레인저 api 명세서",
-		version = "v1"))
-@Configuration
-public class SwaggerConfig {
-
-	@Bean
-	public GroupedOpenApi userOpenApi() {
-		String[] paths = {"/members/**", "/sign-up", "/login"};
-
-		return GroupedOpenApi.builder()
-			.group("유저 API v1")
-			.pathsToMatch(paths)
-			.build();
-	}
-
-	@Bean
-	public GroupedOpenApi surveyOpenApi() {
-		String[] paths = {"/surveys/**"};
-
-		return GroupedOpenApi.builder()
-			.group("설문 API v1")
-			.pathsToMatch(paths)
-			.build();
-	}
-
-	@Bean
-	public GroupedOpenApi responseOpenApi() {
-		String[] paths = {"/responses/**", "/invited-surveys"};
-
-		return GroupedOpenApi.builder()
-			.group("응답 API v1")
-			.pathsToMatch(paths)
-			.build();
-	}
-}
+// package com.devcourse.ReviewRanger.common.config;
+//
+// import org.springdoc.core.models.GroupedOpenApi;
+// import org.springframework.context.annotation.Bean;
+// import org.springframework.context.annotation.Configuration;
+//
+// import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+// import io.swagger.v3.oas.annotations.info.Info;
+//
+// @OpenAPIDefinition(
+// 	info = @Info(title = "리뷰레인저 서비스",
+// 		description = "리뷰레인저 api 명세서",
+// 		version = "v1"))
+// @Configuration
+// public class SwaggerConfig {
+//
+// 	@Bean
+// 	public GroupedOpenApi userOpenApi() {
+// 		String[] paths = {"/members/**", "/sign-up", "/login"};
+//
+// 		return GroupedOpenApi.builder()
+// 			.group("유저 API v1")
+// 			.pathsToMatch(paths)
+// 			.build();
+// 	}
+//
+// 	@Bean
+// 	public GroupedOpenApi surveyOpenApi() {
+// 		String[] paths = {"/surveys/**"};
+//
+// 		return GroupedOpenApi.builder()
+// 			.group("설문 API v1")
+// 			.pathsToMatch(paths)
+// 			.build();
+// 	}
+//
+// 	@Bean
+// 	public GroupedOpenApi responseOpenApi() {
+// 		String[] paths = {"/responses/**", "/invited-surveys"};
+//
+// 		return GroupedOpenApi.builder()
+// 			.group("응답 API v1")
+// 			.pathsToMatch(paths)
+// 			.build();
+// 	}
+// }

--- a/src/main/java/com/devcourse/ReviewRanger/eachSurveyResult/domain/EachSurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/eachSurveyResult/domain/EachSurveyResult.java
@@ -1,10 +1,11 @@
 package com.devcourse.ReviewRanger.eachSurveyResult.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/Question.java
@@ -3,16 +3,17 @@ package com.devcourse.ReviewRanger.question.domain;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
+++ b/src/main/java/com/devcourse/ReviewRanger/question/domain/QuestionOption.java
@@ -1,14 +1,15 @@
 package com.devcourse.ReviewRanger.question.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/response/api/ResponseRestController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/response/api/ResponseRestController.java
@@ -1,5 +1,7 @@
 package com.devcourse.ReviewRanger.response.api;
 
+import javax.validation.Valid;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -8,8 +10,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.ReviewRanger.response.application.ResponseService;
 import com.devcourse.ReviewRanger.response.dto.request.CreateResponse;
-
-import jakarta.validation.Valid;
 
 @RestController
 public class ResponseRestController {
@@ -22,7 +22,6 @@ public class ResponseRestController {
 
 	@PostMapping(value = "/invited-surveys")
 	public ResponseEntity<Boolean> create(@RequestBody @Valid CreateResponse request) {
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(responseService.createResponse(request));
+		return ResponseEntity.status(HttpStatus.CREATED).body(responseService.createResponse(request));
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/response/domain/Response.java
+++ b/src/main/java/com/devcourse/ReviewRanger/response/domain/Response.java
@@ -1,11 +1,12 @@
 package com.devcourse.ReviewRanger.response.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Lob;
+import javax.persistence.Table;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Lob;
-import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/domain/Survey.java
@@ -4,16 +4,17 @@ import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
 
 import java.time.LocalDateTime;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Size;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/domain/SurveyResult.java
@@ -1,12 +1,13 @@
 package com.devcourse.ReviewRanger.surveyresult.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.EnumType;
+import javax.persistence.Enumerated;
+import javax.persistence.Table;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.Table;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/controller/UserController.java
@@ -1,5 +1,7 @@
 package com.devcourse.ReviewRanger.user.controller;
 
+import javax.validation.Valid;
+
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
@@ -8,8 +10,6 @@ import com.devcourse.ReviewRanger.user.dto.JoinRequest;
 import com.devcourse.ReviewRanger.user.dto.ValidateEmailRequest;
 import com.devcourse.ReviewRanger.user.dto.ValidateNameRequest;
 import com.devcourse.ReviewRanger.user.service.UserService;
-
-import jakarta.validation.Valid;
 
 @RestController
 public class UserController {

--- a/src/main/java/com/devcourse/ReviewRanger/user/domain/User.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/domain/User.java
@@ -2,13 +2,14 @@ package com.devcourse.ReviewRanger.user.domain;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
+
 import com.devcourse.ReviewRanger.BaseEntity;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
 import lombok.Getter;
 
 @Getter

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/JoinRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/JoinRequest.java
@@ -2,11 +2,11 @@ package com.devcourse.ReviewRanger.user.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 
-import com.devcourse.ReviewRanger.user.domain.User;
+import javax.persistence.Column;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
-import jakarta.persistence.Column;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import com.devcourse.ReviewRanger.user.domain.User;
 
 public record JoinRequest(
 	@Column(nullable = false, length = 20)

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateEmailRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateEmailRequest.java
@@ -2,9 +2,9 @@ package com.devcourse.ReviewRanger.user.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 
-import jakarta.persistence.Column;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import javax.persistence.Column;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 public record ValidateEmailRequest(
 	@Column(nullable = false, length = 30)

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateNameRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/ValidateNameRequest.java
@@ -2,9 +2,9 @@ package com.devcourse.ReviewRanger.user.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 
-import jakarta.persistence.Column;
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import javax.persistence.Column;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Pattern;
 
 public record ValidateNameRequest(
 	@Column(nullable = false, length = 20)


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 시큐리티 6.0 이하 버전 사용을 위해 스프링부트를 2.7.17을 사용했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 버전변경에 따라 jakarta에서 javax변경작업이 있었습니다.
- 버전변경에 따라 'org.springdoc:springdoc-openapi-starter-webmvc-ui' 가 적용되지 않아 주석처리해두었습니다.
  역할이 있던 부분이라 함부로 고치지 않았습니다. 논의 후 제가 변경해도 괜찮을 것 같습니다. 
- 버전변경에 따른 스프링 시큐리 설정파일변경은 "버전변경에 따라 변경된 부분을 전달하기 위한 커밋" 로 빼놓았습니다.


