### PR TITLE
[REV-139] Ranger 프로젝트 공통 응답 객체 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -1,17 +1,23 @@
 package com.devcourse.ReviewRanger.common.exception;
 
+import static org.springframework.http.HttpStatus.*;
+
+import org.springframework.http.HttpStatus;
+
 import lombok.Getter;
 
 @Getter
 public enum ErrorCode {
 
 	// 409 error
-	EXIST_SAME_NAME("이미 사용중인 이름 입니다."),
-	EXIST_SAME_EMAIL("이미 사용중인 이메일 입니다.");
+	EXIST_SAME_NAME(CONFLICT, "이미 사용중인 이름 입니다."),
+	EXIST_SAME_EMAIL(CONFLICT, "이미 사용중인 이메일 입니다.");
 
+	private final HttpStatus httpStatus;
 	private final String message;
 
-	ErrorCode(String message) {
+	ErrorCode(HttpStatus httpStatus, String message) {
+		this.httpStatus = httpStatus;
 		this.message = message;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/GlobalExceptionHandler.java
@@ -1,8 +1,8 @@
 package com.devcourse.ReviewRanger.common.exception;
 
-import static com.devcourse.ReviewRanger.common.exception.RangerException.*;
 import static org.springframework.http.HttpStatus.*;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseBody;
@@ -11,24 +11,31 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+	public record ErrorResponse(
+		HttpStatus status,
+		String errorCode,
+		String message
+	) {
+	}
+
 	@ExceptionHandler(RangerException.class)
 	@ResponseBody
 	public ErrorResponse handleRangerException(RangerException e) {
 		ErrorCode errorCode = e.getErrorCode();
-		return new ErrorResponse(errorCode.name(), errorCode.getMessage());
+		return new ErrorResponse(errorCode.getHttpStatus(), errorCode.name(), errorCode.getMessage());
 	}
 
 	@ExceptionHandler(MethodArgumentNotValidException.class)
 	@ResponseBody
 	public ErrorResponse handleRangerException(MethodArgumentNotValidException e) {
 		String errorMessage = e.getBindingResult().getAllErrors().get(0).getDefaultMessage();
-		return new ErrorResponse(BAD_REQUEST.name(), errorMessage);
+		return new ErrorResponse(BAD_REQUEST, BAD_REQUEST.name(), errorMessage);
 	}
 
 	@ExceptionHandler(RuntimeException.class)
 	@ResponseBody
 	public ErrorResponse handleRuntimeException(RuntimeException e) {
-		return new ErrorResponse(INTERNAL_SERVER_ERROR.name(), e.getMessage());
+		return new ErrorResponse(INTERNAL_SERVER_ERROR, INTERNAL_SERVER_ERROR.name(), e.getMessage());
 	}
 
 }

--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/RangerException.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/RangerException.java
@@ -5,12 +5,6 @@ import lombok.Getter;
 @Getter
 public class RangerException extends RuntimeException {
 
-	public record ErrorResponse(
-		String errorCode,
-		String message
-	) {
-	}
-
 	private final ErrorCode errorCode;
 
 	public RangerException(ErrorCode errorCode) {

--- a/src/main/java/com/devcourse/ReviewRanger/common/response/RangerResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/response/RangerResponse.java
@@ -1,0 +1,29 @@
+package com.devcourse.ReviewRanger.common.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+@JsonPropertyOrder({"success", "data"})
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class RangerResponse<T> {
+
+	private final Boolean success;
+	private final T data;
+
+	public RangerResponse(Boolean success, T data) {
+		this.success = success;
+		this.data = data;
+	}
+
+	public static RangerResponse<Void> ok(Boolean success) {
+		return new RangerResponse<>(success, null);
+	}
+
+	public static <T> RangerResponse<T> ok(T data) {
+		return new RangerResponse<>(true, data);
+	}
+
+	public static RangerResponse<Void> noData() {
+		return new RangerResponse<>(true, null);
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- Ranger 프로젝트 공통 응답 객체 추가
- ErrorCode에 HttpStatus를 추가함으로서 실패시 클라이언트에게 HttpStatus도 넘기도록 수정

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 앞으로 Controller에 ResponseEntity말고 RangerResponse를 쓰면 될 것 같습니다!!
- 클라이언트에게 반환 할 내용이 더 필요하다면 추후에 추가하도록 하겠습니다.


