### PR TITLE
[REV-123] 작성자별 응답 결과 전체 조회 기능 구현

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/survey/dto/response/SurveyResponseDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/survey/dto/response/SurveyResponseDto.java
@@ -1,0 +1,32 @@
+package com.devcourse.ReviewRanger.survey.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.devcourse.ReviewRanger.survey.domain.SurveyType;
+
+public record SurveyResponseDto(
+	Long surveyId,
+	String title,
+	String description,
+	SurveyType surveyType,
+	LocalDateTime closeAt,
+	LocalDateTime createdAt,
+	LocalDateTime updatedAt
+) {
+	public SurveyResponseDto(
+		Long surveyId,
+		String title,
+		SurveyType surveyType,
+		LocalDateTime createdAt,
+		LocalDateTime updatedAt) {
+		this(
+			surveyId,
+			title,
+			null,
+			surveyType,
+			null,
+			createdAt,
+			updatedAt
+		);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/api/SurveyResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/api/SurveyResultController.java
@@ -10,6 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.ReviewRanger.surveyresult.application.SurveyResultService;
 import com.devcourse.ReviewRanger.surveyresult.domain.SurveyResult;
+import com.devcourse.ReviewRanger.surveyresult.dto.response.AllResponserResultResponseDto;
 
 @RestController
 public class SurveyResultController {
@@ -27,4 +28,12 @@ public class SurveyResultController {
 		return new ResponseEntity<List<SurveyResult>>(sersurveyResults, HttpStatus.OK);
 	}
 
+	@GetMapping("/created-surveys/{surveyId}/responser/{userId}")
+	public ResponseEntity<AllResponserResultResponseDto> getAllReponserServeyResult(@PathVariable Long surveyId,
+		@PathVariable Long userId) {
+		AllResponserResultResponseDto allReponserSurveyResult = surveyResultService.getAllReponserSurveyResult(
+			surveyId, userId);
+
+		return ResponseEntity.status(HttpStatus.OK).body(allReponserSurveyResult);
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/application/SurveyResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/application/SurveyResultService.java
@@ -1,22 +1,35 @@
 package com.devcourse.ReviewRanger.surveyresult.application;
 
-
+import java.util.ArrayList;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.devcourse.ReviewRanger.survey.domain.Survey;
+import com.devcourse.ReviewRanger.survey.dto.response.SurveyResponseDto;
+import com.devcourse.ReviewRanger.survey.repository.SurveyRepository;
 import com.devcourse.ReviewRanger.surveyresult.domain.SurveyResult;
+import com.devcourse.ReviewRanger.surveyresult.dto.response.AllResponserResultResponseDto;
+import com.devcourse.ReviewRanger.surveyresult.dto.response.Responsers;
 import com.devcourse.ReviewRanger.surveyresult.repository.SurveyResultRepository;
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
 @Service
 @Transactional(readOnly = true)
 public class SurveyResultService {
 
 	private final SurveyResultRepository surveyResultRepository;
+	private final UserRepository userRepository;
+	private final SurveyRepository surveyRepository;
 
-	public SurveyResultService(SurveyResultRepository surveyResultRepository) {
+	public SurveyResultService(SurveyResultRepository surveyResultRepository, UserRepository userRepository,
+		SurveyRepository surveyRepository) {
 		this.surveyResultRepository = surveyResultRepository;
+		this.userRepository = userRepository;
+		this.surveyRepository = surveyRepository;
 	}
 
 	@Transactional
@@ -27,9 +40,35 @@ public class SurveyResultService {
 
 	public List<SurveyResult> getResponserSurveyResult(Long responserId) {
 		return surveyResultRepository.findByResponserId(responserId);
-  }
-  
+	}
+
 	public SurveyResult findSurveyResult(Long surveyId, Long responserId) {
 		return surveyResultRepository.findBySurveyIdAndResponserId(surveyId, responserId);
+	}
+
+	public AllResponserResultResponseDto getAllReponserSurveyResult(Long surveyId, Long userId) {
+		Survey survey = surveyRepository.findById(surveyId)
+			.orElseThrow(() -> new NoSuchElementException("설문이 존재하지 않습니다."));
+
+		SurveyResponseDto surveyResponseDto = new SurveyResponseDto(surveyId, survey.getTitle(),
+			survey.getType(), survey.getCreateAt(), survey.getUpdatedAt());
+
+		List<SurveyResult> surveyResults = surveyResultRepository.findBySurveyIdAndQuestionAnsweredStatusTrue(surveyId);
+
+		ArrayList<Responsers> responserList = new ArrayList<>();
+		AllResponserResultResponseDto allResponserResultResponseDto = new AllResponserResultResponseDto(
+			surveyResults.size(), surveyResponseDto, responserList);
+
+		for (SurveyResult surveyResult : surveyResults) {
+			User user = userRepository.findById(surveyResult.getResponserId())
+				.orElseThrow(() -> new NoSuchElementException("사용자가 존재하지 않습니다."));
+
+			Responsers responser = new Responsers(surveyResult.getId(), user.getId(), user.getName(),
+				surveyResult.getUpdatedAt());
+
+			allResponserResultResponseDto.responsers().add(responser);
+		}
+
+		return allResponserResultResponseDto;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/AllResponserResultResponseDto.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/AllResponserResultResponseDto.java
@@ -1,0 +1,14 @@
+package com.devcourse.ReviewRanger.surveyresult.dto.response;
+
+import java.util.List;
+
+import com.devcourse.ReviewRanger.survey.dto.response.SurveyResponseDto;
+
+public record AllResponserResultResponseDto(
+	int responserCount,
+
+	SurveyResponseDto surveyResponseDto,
+
+	List<Responsers> responsers
+) {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/Responsers.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/Responsers.java
@@ -1,0 +1,14 @@
+package com.devcourse.ReviewRanger.surveyresult.dto.response;
+
+import java.time.LocalDateTime;
+
+public record Responsers(
+	Long surveyResultId,
+
+	Long id, //responserId
+
+	String name, //responserName
+
+	LocalDateTime updatedAt
+) {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/Responsers.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/dto/response/Responsers.java
@@ -2,12 +2,16 @@ package com.devcourse.ReviewRanger.surveyresult.dto.response;
 
 import java.time.LocalDateTime;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public record Responsers(
 	Long surveyResultId,
 
-	Long id, //responserId
+	@JsonProperty("id")
+	Long responserId,
 
-	String name, //responserName
+	@JsonProperty("name")
+	String responserName,
 
 	LocalDateTime updatedAt
 ) {

--- a/src/main/java/com/devcourse/ReviewRanger/surveyresult/repository/SurveyResultRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/surveyresult/repository/SurveyResultRepository.java
@@ -11,4 +11,6 @@ public interface SurveyResultRepository extends JpaRepository<SurveyResult, Long
 	List<SurveyResult> findByResponserId(Long responserId);
 
 	SurveyResult findBySurveyIdAndResponserId(Long surveyId, Long responserId);
+
+	List<SurveyResult> findBySurveyIdAndQuestionAnsweredStatusTrue(Long surveyId);
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 작성자별 응답 결과 전체 조회 기능을 구현하였습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 설문 결과에서 설문 Id가 같으면서 설문에 참여한 컬럼의 갯수를 responserCount로 넣었습니다.
- 설문 단일 조회와 사용자 단일 조회를 충돌을 방지하기 위해 Repository에서 조회에서 사용하였습니다. 추후에 Service의 로직으로 변경할 예정입니다.
- 다음 pr부터 custom RresponseEntitiy 기능을 적용하도록 하겠습니다.
- 다음 pr부터 custom Exception을 적용하도록 하겠습니다.
- 요청자를 식별하기 위해 임시로 pathVariable을 통해 식별값을 받았습니다.

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 테스트코드
