### PR TITLE
[REV-126] 유저별 리뷰 결과 전체 조회 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
@@ -1,0 +1,35 @@
+package com.devcourse.ReviewRanger.finalReviewResult.api;
+
+import java.util.List;
+
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devcourse.ReviewRanger.common.response.RangerResponse;
+import com.devcourse.ReviewRanger.finalReviewResult.application.FinalReviewResultService;
+import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListResponse;
+import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+
+@RestController
+@RequestMapping("/final-results")
+public class FinalReviewResultController {
+
+	private final FinalReviewResultService finalReviewResultService;
+
+	public FinalReviewResultController(FinalReviewResultService finalReviewResultService) {
+		this.finalReviewResultService = finalReviewResultService;
+	}
+
+	@GetMapping
+	public RangerResponse<List<FinalReviewResultListResponse>> getAllFinalReviewResults(
+		@AuthenticationPrincipal UserPrincipal user
+	) {
+		List<FinalReviewResultListResponse> allFinalReviewResults
+			= finalReviewResultService.getAllFinalReviewResults(user.getId());
+
+		return RangerResponse.ok(allFinalReviewResults);
+	}
+
+}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -21,6 +21,6 @@ public class FinalReviewResultService {
 	public List<FinalReviewResultListResponse> getAllFinalReviewResults(Long userId) {
 		return finalReviewResultRepository.findAllByUserId(userId)
 			.stream()
-			.map(FinalReviewResultListResponse::from).toList();
+			.map(FinalReviewResultListResponse::new).toList();
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -1,0 +1,26 @@
+package com.devcourse.ReviewRanger.finalReviewResult.application;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListResponse;
+import com.devcourse.ReviewRanger.finalReviewResult.repository.FinalReviewResultRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class FinalReviewResultService {
+
+	private final FinalReviewResultRepository finalReviewResultRepository;
+
+	public FinalReviewResultService(FinalReviewResultRepository finalReviewResultRepository) {
+		this.finalReviewResultRepository = finalReviewResultRepository;
+	}
+
+	public List<FinalReviewResultListResponse> getAllFinalReviewResults(Long userId) {
+		return finalReviewResultRepository.findAllByUserId(userId)
+			.stream()
+			.map(FinalReviewResultListResponse::from).toList();
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
@@ -8,6 +8,9 @@ import javax.validation.constraints.Size;
 
 import com.devcourse.ReviewRanger.BaseEntity;
 
+import lombok.Getter;
+
+@Getter
 @Entity
 @Table(name = "final_review_results")
 public class FinalReviewResult extends BaseEntity {
@@ -16,12 +19,12 @@ public class FinalReviewResult extends BaseEntity {
 	@NotBlank(message = "리뷰 대상 id는 빈값 일 수 없습니다.")
 	private Long userId;
 
-	@Column(name = "survey_id", nullable = false)
-	@NotBlank(message = "설문 id는 빈값 일 수 없습니다.")
+	@Column(name = "review_id", nullable = false)
+	@NotBlank(message = "리뷰 id는 빈값 일 수 없습니다.")
 	private Long reviewId;
 
 	@Column(nullable = false, length = 50)
-	@NotBlank(message = "설문제목은 빈값 일 수 없습니다.")
+	@NotBlank(message = "리뷰 제목은 빈값 일 수 없습니다.")
 	@Size(max = 50, message = "50자 이하로 입력하세요.")
 	private String title;
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultReply.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultReply.java
@@ -14,18 +14,18 @@ import com.devcourse.ReviewRanger.question.domain.QuestionType;
 
 @Entity
 @Table(name = "final_review_replies")
-public class FinalReviewReply extends BaseEntity {
+public class FinalReviewResultReply extends BaseEntity {
 
-	@Column(name = "after_result_id", nullable = false)
-	@NotBlank(message = "조합된 결과 id는 빈값 일 수 없습니다.")
-	private Long afterResultId;
+	@Column(name = "final_review_result_id", nullable = false)
+	@NotBlank(message = "최종 리뷰 결과 id는 빈값 일 수 없습니다.")
+	private Long finalReviewResultId;
 
 	@Column(name = "question_type", nullable = false)
 	@Enumerated(EnumType.STRING)
 	private QuestionType questionType;
 
 	@Column(name = "question_title", nullable = false)
-	@NotBlank(message = "질문제목은 빈값 일 수 없습니다.")
+	@NotBlank(message = "질문 제목은 빈값 일 수 없습니다.")
 	@Size(max = 150, message = "150자 이하로 입력하세요.")
 	private String questionTitle;
 

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/FinalReviewResultListResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/FinalReviewResultListResponse.java
@@ -9,8 +9,8 @@ public record FinalReviewResultListResponse(
 	String title,
 	LocalDateTime created_at
 ) {
-	public static FinalReviewResultListResponse from(FinalReviewResult finalReviewResult) {
-		return new FinalReviewResultListResponse(
+	public FinalReviewResultListResponse(FinalReviewResult finalReviewResult) {
+		this(
 			finalReviewResult.getId(),
 			finalReviewResult.getTitle(),
 			finalReviewResult.getCreateAt()

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/FinalReviewResultListResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/FinalReviewResultListResponse.java
@@ -1,0 +1,19 @@
+package com.devcourse.ReviewRanger.finalReviewResult.dto;
+
+import java.time.LocalDateTime;
+
+import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResult;
+
+public record FinalReviewResultListResponse(
+	Long id,
+	String title,
+	LocalDateTime created_at
+) {
+	public static FinalReviewResultListResponse from(FinalReviewResult finalReviewResult) {
+		return new FinalReviewResultListResponse(
+			finalReviewResult.getId(),
+			finalReviewResult.getTitle(),
+			finalReviewResult.getCreateAt()
+		);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultReplyRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultReplyRepository.java
@@ -1,0 +1,8 @@
+package com.devcourse.ReviewRanger.finalReviewResult.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultReply;
+
+public interface FinalReviewResultReplyRepository extends JpaRepository<FinalReviewResultReply, Long> {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultRepository.java
@@ -1,0 +1,11 @@
+package com.devcourse.ReviewRanger.finalReviewResult.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResult;
+
+public interface FinalReviewResultRepository extends JpaRepository<FinalReviewResult, Long> {
+	List<FinalReviewResult> findAllByUserId(Long userId);
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 유저의 마이페이지에서 자신에 대한 리뷰 결과를 전체 조회할 수 있는 기능입니다.
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/4afe69ff-221f-40c2-b82b-e9e388f165df)

- 응답은 아래와 같이 옵니다.
<img width="482" alt="스크린샷 2023-11-07 오전 2 47 00" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/202a2e80-b037-436d-aa78-00c8e7a809d8">

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 다음으론 최종 리뷰 결과를 생성하는 API 구현 하고 이후 리뷰 결과 상세 조회 기능을 구현하겠습니다!
- DTO에서 Entity를 받아 DTO를 반환하는 로직으로 변환 로직을 구현하였습니다.
- 마이페이지에서 자신의 리뷰 결과를 받아야 하므로 유저 토큰이 필요합니다.


