### PR TITLE
[REV-164] 응답자의 참여 전체조회 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
@@ -29,12 +29,12 @@ public class ParticipationController {
 	}
 
 	@GetMapping("/participations")
-	public ResponseEntity<List<GetParticipationResponse>> getAllReviewsByResponser(
+	public RangerResponse<List<GetParticipationResponse>> getAllReviewsByResponser(
 		@AuthenticationPrincipal UserPrincipal user) {
 		Long responserId = user.getId();
 		List<GetParticipationResponse> responses = participationService.getAllReviewsByResponser(responserId);
 
-		return new ResponseEntity<>(responses, HttpStatus.OK);
+		return RangerResponse.ok(responses);
 	}
 
 	/**

--- a/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -12,10 +13,11 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.ReviewRanger.common.response.RangerResponse;
 import com.devcourse.ReviewRanger.participation.application.ParticipationService;
-import com.devcourse.ReviewRanger.participation.domain.Participation;
 import com.devcourse.ReviewRanger.participation.dto.request.SubmitParticipationRequest;
 import com.devcourse.ReviewRanger.participation.dto.response.AllResponserParticipateInReviewResponse;
+import com.devcourse.ReviewRanger.participation.dto.response.GetParticipationResponse;
 import com.devcourse.ReviewRanger.participation.dto.response.SubjectResponse;
+import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
 
 @RestController
 public class ParticipationController {
@@ -26,34 +28,33 @@ public class ParticipationController {
 		this.participationService = participationService;
 	}
 
-	@GetMapping("/invited-surveys/{responserId}")
-	public ResponseEntity<List<Participation>> getResponserSurveyResult(@PathVariable Long responserId) {
-		List<Participation> sersurveyResults = participationService.getResponserSurveyResult(responserId);
+	@GetMapping("/participations")
+	public ResponseEntity<List<GetParticipationResponse>> getAllReviewsByResponser(
+		@AuthenticationPrincipal UserPrincipal user) {
+		Long responserId = user.getId();
+		List<GetParticipationResponse> responses = participationService.getAllReviewsByResponser(responserId);
 
-		return new ResponseEntity<List<Participation>>(sersurveyResults, HttpStatus.OK);
+		return new ResponseEntity<>(responses, HttpStatus.OK);
 	}
 
 	/**
 	 * 설문에 참여한 모든 응답자 조회
 	 */
-	@GetMapping("/created-surveys/{surveyId}/responser")
-	public RangerResponse<AllResponserParticipateInReviewResponse> getAllReponserParticipateInSurvey(
-		@PathVariable Long surveyId) {
-		AllResponserParticipateInReviewResponse response = participationService.getAllReponserParticipateInReviewOrThrow(
-			surveyId);
-
-		return RangerResponse.ok(response);
-	}
+	// @GetMapping("/created-surveys/{surveyId}/responser")
+	// public RangerResponse<AllResponserParticipateInReviewResponse> getAllReponserParticipateInSurvey(
+	// 	@PathVariable Long surveyId) {
+	// 	AllResponserParticipateInReviewResponse response = participationService.getAllReponserParticipateInReviewOrThrow(
+	// 		surveyId);
+	//
+	// 	return RangerResponse.ok(response);
+	// }
 
 	/**
 	 * 리뷰를 받은 사용자 전체 조회 기능
 	 */
 	@GetMapping("/created-surveys/{surveyId}/recipient")
-	public RangerResponse<List<SubjectResponse>> getAllRecipientParticipateInSurvey(
-		@PathVariable Long surveyId
-	) {
-		List<SubjectResponse> response = participationService.getAllRecipientParticipateInReviewOrThrow(
-			surveyId);
+	public RangerResponse<List<SubjectResponse>> getAllRecipientParticipateInSurvey(@PathVariable Long surveyId) {
+		List<SubjectResponse> response = participationService.getAllRecipientParticipateInReviewOrThrow(surveyId);
 
 		return RangerResponse.ok(response);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
@@ -40,14 +40,14 @@ public class ParticipationController {
 	/**
 	 * 설문에 참여한 모든 응답자 조회
 	 */
-	// @GetMapping("/created-surveys/{surveyId}/responser")
-	// public RangerResponse<AllResponserParticipateInReviewResponse> getAllReponserParticipateInSurvey(
-	// 	@PathVariable Long surveyId) {
-	// 	AllResponserParticipateInReviewResponse response = participationService.getAllReponserParticipateInReviewOrThrow(
-	// 		surveyId);
-	//
-	// 	return RangerResponse.ok(response);
-	// }
+	@GetMapping("/created-surveys/{surveyId}/responser")
+	public RangerResponse<AllResponserParticipateInReviewResponse> getAllReponserParticipateInSurvey(
+		@PathVariable Long surveyId) {
+		AllResponserParticipateInReviewResponse response = participationService.getAllReponserParticipateInReviewOrThrow(
+			surveyId);
+
+		return RangerResponse.ok(response);
+	}
 
 	/**
 	 * 리뷰를 받은 사용자 전체 조회 기능

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -15,6 +15,7 @@ import com.devcourse.ReviewRanger.participation.domain.DeadlineStatus;
 import com.devcourse.ReviewRanger.participation.domain.Participation;
 import com.devcourse.ReviewRanger.participation.dto.request.SubmitParticipationRequest;
 import com.devcourse.ReviewRanger.participation.dto.response.AllResponserParticipateInReviewResponse;
+import com.devcourse.ReviewRanger.participation.dto.response.GetParticipationResponse;
 import com.devcourse.ReviewRanger.participation.dto.response.ResponserResponse;
 import com.devcourse.ReviewRanger.participation.dto.response.SubjectResponse;
 import com.devcourse.ReviewRanger.participation.repository.ParticipationRepository;
@@ -57,14 +58,12 @@ public class ParticipationService {
 		return true;
 	}
 
-	public List<Participation> getResponserSurveyResult(Long responserId) {
-		return participationRepository.findByResponserId(responserId);
-	}
-
 	public Long getResponserCount(Long reviewId) {
 		List<Participation> participations = getAllByReviewId(reviewId);
 
-		return participations.stream().filter(surveyResult -> surveyResult.getQuestionAnsweredStatus()).count();
+		return participations.stream()
+			.filter(surveyResult -> surveyResult.getDeadlineStatus() == DeadlineStatus.DEADLINE)
+			.count();
 	}
 
 	@Transactional
@@ -108,8 +107,7 @@ public class ParticipationService {
 		List<Participation> participations = getAllByReviewId(reviewId);
 
 		for (Participation participation : participations) {
-			List<ReviewedTarget> reviewedTargets = reviewedTargetService.getAllByParticipationId(
-				participation.getId());
+			List<ReviewedTarget> reviewedTargets = reviewedTargetService.getAllByParticipationId(participation.getId());
 
 			for (ReviewedTarget reviewedTarget : reviewedTargets) {
 				Long subjectId = reviewedTarget.getSubjectId();

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -19,6 +19,7 @@ import com.devcourse.ReviewRanger.participation.dto.response.GetParticipationRes
 import com.devcourse.ReviewRanger.participation.dto.response.ResponserResponse;
 import com.devcourse.ReviewRanger.participation.dto.response.SubjectResponse;
 import com.devcourse.ReviewRanger.participation.repository.ParticipationRepository;
+import com.devcourse.ReviewRanger.review.application.ReviewService;
 import com.devcourse.ReviewRanger.review.domain.Review;
 import com.devcourse.ReviewRanger.review.dto.response.ReviewResponseDto;
 import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
@@ -58,6 +59,23 @@ public class ParticipationService {
 		return true;
 	}
 
+	public List<GetParticipationResponse> getAllReviewsByResponser(Long responserId) {
+		List<Participation> participations = participationRepository.findByResponserId(responserId);
+
+		List<GetParticipationResponse> getParticipationResponses = new ArrayList<>();
+
+		for (Participation participation : participations) {
+			Long reviewId = participation.getReviewId();
+			Review review = reviewRepository.findById(reviewId).orElseThrow(() -> new RangerException(NOT_FOUND_REPLY));
+			String title = review.getTitle();
+
+			GetParticipationResponse getParticipationResponse = new GetParticipationResponse(participation, title);
+			getParticipationResponses.add(getParticipationResponse);
+		}
+
+		return getParticipationResponses;
+	}
+
 	public Long getResponserCount(Long reviewId) {
 		List<Participation> participations = getAllByReviewId(reviewId);
 
@@ -74,31 +92,31 @@ public class ParticipationService {
 		return true;
 	}
 
-	public AllResponserParticipateInReviewResponse getAllReponserParticipateInReviewOrThrow(Long reviewId) {
-		Review review = reviewRepository.findById(reviewId)
-			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
-
-		ReviewResponseDto reviewResponseDto = new ReviewResponseDto(review);
-
-		List<Participation> participations = participationRepository.findByReviewIdAndQuestionAnsweredStatusTrue(
-			reviewId);
-
-		ArrayList<ResponserResponse> responsers = new ArrayList<>();
-		AllResponserParticipateInReviewResponse allResponserParticipateInReviewDto = new AllResponserParticipateInReviewResponse(
-			participations.size(), reviewResponseDto, responsers);
-
-		for (Participation participation : participations) {
-			User user = userRepository.findById(participation.getResponserId())
-				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
-
-			ResponserResponse responser = new ResponserResponse(participation.getId(), user.getId(), user.getName(),
-				participation.getUpdatedAt());
-
-			allResponserParticipateInReviewDto.responsers().add(responser);
-		}
-
-		return allResponserParticipateInReviewDto;
-	}
+	// public AllResponserParticipateInReviewResponse getAllReponserParticipateInReviewOrThrow(Long reviewId) {
+	// 	Review review = reviewRepository.findById(reviewId)
+	// 		.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
+	//
+	// 	ReviewResponseDto reviewResponseDto = new ReviewResponseDto(review);
+	//
+	// 	List<Participation> participations = participationRepository.findByReviewIdAndQuestionAnsweredStatusTrue(
+	// 		reviewId);
+	//
+	// 	ArrayList<ResponserResponse> responsers = new ArrayList<>();
+	// 	AllResponserParticipateInReviewResponse allResponserParticipateInReviewDto = new AllResponserParticipateInReviewResponse(
+	// 		participations.size(), reviewResponseDto, responsers);
+	//
+	// 	for (Participation participation : participations) {
+	// 		User user = userRepository.findById(participation.getResponserId())
+	// 			.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
+	//
+	// 		ResponserResponse responser = new ResponserResponse(participation.getId(), user.getId(), user.getName(),
+	// 			participation.getUpdatedAt());
+	//
+	// 		allResponserParticipateInReviewDto.responsers().add(responser);
+	// 	}
+	//
+	// 	return allResponserParticipateInReviewDto;
+	// }
 
 	public List<SubjectResponse> getAllRecipientParticipateInReviewOrThrow(Long reviewId) {
 		List<SubjectResponse> responses = new ArrayList<>();

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -80,43 +80,44 @@ public class ParticipationService {
 		List<Participation> participations = getAllByReviewId(reviewId);
 
 		return participations.stream()
-			.filter(surveyResult -> surveyResult.getDeadlineStatus() == DeadlineStatus.DEADLINE)
+			.filter(participation -> participation.getDeadlineStatus() == DeadlineStatus.DEADLINE)
 			.count();
 	}
 
 	@Transactional
 	public Boolean closeParticipationOrThrow(Long reviewId) {
 		List<Participation> participations = getAllByReviewId(reviewId);
-		participations.stream().forEach(surveyResult -> surveyResult.changeStatus(DeadlineStatus.END));
+		participations.stream().forEach(participation -> participation.changeStatus(DeadlineStatus.END));
 
 		return true;
 	}
 
-	// public AllResponserParticipateInReviewResponse getAllReponserParticipateInReviewOrThrow(Long reviewId) {
-	// 	Review review = reviewRepository.findById(reviewId)
-	// 		.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
-	//
-	// 	ReviewResponseDto reviewResponseDto = new ReviewResponseDto(review);
-	//
-	// 	List<Participation> participations = participationRepository.findByReviewIdAndQuestionAnsweredStatusTrue(
-	// 		reviewId);
-	//
-	// 	ArrayList<ResponserResponse> responsers = new ArrayList<>();
-	// 	AllResponserParticipateInReviewResponse allResponserParticipateInReviewDto = new AllResponserParticipateInReviewResponse(
-	// 		participations.size(), reviewResponseDto, responsers);
-	//
-	// 	for (Participation participation : participations) {
-	// 		User user = userRepository.findById(participation.getResponserId())
-	// 			.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
-	//
-	// 		ResponserResponse responser = new ResponserResponse(participation.getId(), user.getId(), user.getName(),
-	// 			participation.getUpdatedAt());
-	//
-	// 		allResponserParticipateInReviewDto.responsers().add(responser);
-	// 	}
-	//
-	// 	return allResponserParticipateInReviewDto;
-	// }
+	public AllResponserParticipateInReviewResponse getAllReponserParticipateInReviewOrThrow(Long reviewId) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
+
+		ReviewResponseDto reviewResponseDto = new ReviewResponseDto(review);
+
+		List<Participation> participations = participationRepository.findByReviewId(reviewId)
+			.stream()
+			.filter(participation -> participation.getDeadlineStatus() == DeadlineStatus.DEADLINE).toList();
+
+		ArrayList<ResponserResponse> responsers = new ArrayList<>();
+		AllResponserParticipateInReviewResponse allResponserParticipateInReviewDto = new AllResponserParticipateInReviewResponse(
+			participations.size(), reviewResponseDto, responsers);
+
+		for (Participation participation : participations) {
+			User user = userRepository.findById(participation.getResponserId())
+				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
+
+			ResponserResponse responser = new ResponserResponse(participation.getId(), user.getId(), user.getName(),
+				participation.getUpdatedAt());
+
+			allResponserParticipateInReviewDto.responsers().add(responser);
+		}
+
+		return allResponserParticipateInReviewDto;
+	}
 
 	public List<SubjectResponse> getAllRecipientParticipateInReviewOrThrow(Long reviewId) {
 		List<SubjectResponse> responses = new ArrayList<>();

--- a/src/main/java/com/devcourse/ReviewRanger/participation/domain/Participation.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/domain/Participation.java
@@ -1,5 +1,9 @@
 package com.devcourse.ReviewRanger.participation.domain;
 
+import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
+
+import java.time.LocalDateTime;
+
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
@@ -7,6 +11,7 @@ import javax.persistence.Enumerated;
 import javax.persistence.Table;
 
 import com.devcourse.ReviewRanger.BaseEntity;
+import com.fasterxml.jackson.annotation.JsonFormat;
 
 import lombok.Getter;
 
@@ -25,8 +30,9 @@ public class Participation extends BaseEntity {
 	@Enumerated(EnumType.STRING)
 	private DeadlineStatus deadlineStatus;
 
-	@Column(name = "question_answered_status", nullable = false)
-	private Boolean questionAnsweredStatus = false;
+	@Column(name = "submit_At")
+	@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+	private LocalDateTime submitAt;
 
 	protected Participation() {
 	}
@@ -34,7 +40,6 @@ public class Participation extends BaseEntity {
 	public Participation(Long responserId) {
 		this.responserId = responserId;
 		this.deadlineStatus = DeadlineStatus.PROCEEDING;
-		this.questionAnsweredStatus = false;
 	}
 
 	public void assignReviewId(Long reviewId) {

--- a/src/main/java/com/devcourse/ReviewRanger/participation/dto/response/GetParticipationResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/dto/response/GetParticipationResponse.java
@@ -1,0 +1,22 @@
+package com.devcourse.ReviewRanger.participation.dto.response;
+
+import java.time.LocalDateTime;
+
+import com.devcourse.ReviewRanger.participation.domain.DeadlineStatus;
+import com.devcourse.ReviewRanger.participation.domain.Participation;
+
+public record GetParticipationResponse(
+	Long reviewId,
+	String title,
+	LocalDateTime submitAt,
+	DeadlineStatus status
+) {
+	public GetParticipationResponse(Participation participation, String title) {
+		this(
+			participation.getId(),
+			title,
+			participation.getSubmitAt(),
+			participation.getDeadlineStatus()
+		);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/repository/ParticipationRepository.java
@@ -13,6 +13,4 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 	List<Participation> findByReviewId(Long reviewId);
 
 	Participation findByReviewIdAndResponserId(Long reviewId, Long responserId);
-
-	List<Participation> findByReviewIdAndQuestionAnsweredStatusTrue(Long reviewId);
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 응답자의 참여 전체조회 기능을 구현했습니다.
<img width="580" alt="스크린샷 2023-11-07 오후 9 23 09" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/62009283/e426d923-add5-4d9e-b097-92d2d4f84cca">

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 위의 사진에 필요한 데이터를 추가하다보니, 정답작성여부 필드를 삭제하고, 응답일자 필드를 추가했습니다.
- 정답작성여부 필드 삭제에 따른 기존 참여 서비스 로직을 수정했습니다. 범철님 작성 부분을 수정했어서 반드시 확인 부탁드려요.
- 참여 서비스에서 너무 많은 리포지토리를 의존하고 있습니다. 서비스로 변경하려다보니 서비스 빈간 순환참조 오류가 발생했습니다.
  participationService 와 reviewService
- 추후 개선기간에 support 같은 외부 개방 인터페이스를 만들어 수정해야할 것 같습니다.

