### PR TITLE
[REV-170] 초대 받은 리뷰 첫 조회시 리뷰, 질문, 리뷰 대상 정보 제공 api

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -15,6 +15,7 @@ import com.devcourse.ReviewRanger.participation.dto.response.AllResponserPartici
 import com.devcourse.ReviewRanger.participation.dto.response.ReceiverResponse;
 import com.devcourse.ReviewRanger.review.application.ReviewService;
 import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
+import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailFirstResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewResponse;
 import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
@@ -79,15 +80,30 @@ public class ReviewController {
 	}
 
 	@Tag(name = "review")
+	@Operation(summary = "[토큰] 리뷰 첫 상세 조회", description = "[토큰] 리뷰 첫 상세 조회 API", responses = {
+		@ApiResponse(responseCode = "200", description = "리뷰를 첫 상세 조회 성공"),
+		@ApiResponse(responseCode = "404", description = "리뷰가 존재하지 않는 경우")
+	})
+	@GetMapping("/reviews/{id}/first")
+	public RangerResponse<GetReviewDetailFirstResponse> getReviewDetailFirst(
+		@PathVariable("id") Long reviewId,
+		@AuthenticationPrincipal UserPrincipal user
+	) {
+		GetReviewDetailFirstResponse response = reviewService.getReviewDetailFirstOrThrow(reviewId, user.getId());
+
+		return RangerResponse.ok(response);
+	}
+
+	@Tag(name = "review")
 	@Operation(summary = "응답자를 제외한 리뷰의 수신자 전체 조회", description = "응답자를 제외한 리뷰의 수신자 전체 조회 API", responses = {
 		@ApiResponse(responseCode = "200", description = "응답자를 제외한 리뷰의 수신자 전체 조회")
 	})
-	@GetMapping("/reviews/{reviewId}/receiver/{userId}")
+	@GetMapping("/reviews/{reviewId}/responser/{responserId}/receiver")
 	public RangerResponse<List<GetUserResponse>> getAllReceivers(
 		@PathVariable Long reviewId,
-		@PathVariable Long userId
+		@PathVariable Long responserId
 	) {
-		List<GetUserResponse> responses = reviewService.getAllReceivers(reviewId, userId);
+		List<GetUserResponse> responses = reviewService.getAllReceivers(reviewId, responserId);
 
 		return RangerResponse.ok(responses);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -18,6 +18,7 @@ import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewResponse;
 import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.user.dto.GetUserResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -75,6 +76,20 @@ public class ReviewController {
 		GetReviewDetailResponse response = reviewService.getReviewDetailOrThrow(reviewId);
 
 		return RangerResponse.ok(response);
+	}
+
+	@Tag(name = "review")
+	@Operation(summary = "응답자를 제외한 리뷰의 수신자 전체 조회", description = "응답자를 제외한 리뷰의 수신자 전체 조회 API", responses = {
+		@ApiResponse(responseCode = "200", description = "응답자를 제외한 리뷰의 수신자 전체 조회")
+	})
+	@GetMapping("/reviews/{reviewId}/receiver/{userId}")
+	public RangerResponse<List<GetUserResponse>> getAllReceivers(
+		@PathVariable Long reviewId,
+		@PathVariable Long userId
+	) {
+		List<GetUserResponse> responses = reviewService.getAllReceivers(reviewId, userId);
+
+		return RangerResponse.ok(responses);
 	}
 
 	@Tag(name = "review")

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -95,15 +95,15 @@ public class ReviewController {
 	}
 
 	@Tag(name = "review")
-	@Operation(summary = "응답자를 제외한 리뷰의 수신자 전체 조회", description = "응답자를 제외한 리뷰의 수신자 전체 조회 API", responses = {
+	@Operation(summary = "[토큰] 응답자를 제외한 리뷰의 수신자 전체 조회", description = "[토큰] 응답자를 제외한 리뷰의 수신자 전체 조회 API", responses = {
 		@ApiResponse(responseCode = "200", description = "응답자를 제외한 리뷰의 수신자 전체 조회")
 	})
-	@GetMapping("/reviews/{reviewId}/responser/{responserId}/receiver")
+	@GetMapping("/reviews/{reviewId}/responser/receiver")
 	public RangerResponse<List<GetUserResponse>> getAllReceivers(
 		@PathVariable Long reviewId,
-		@PathVariable Long responserId
+		@AuthenticationPrincipal UserPrincipal user
 	) {
-		List<GetUserResponse> responses = reviewService.getAllReceivers(reviewId, responserId);
+		List<GetUserResponse> responses = reviewService.getAllReceivers(reviewId, user.getId());
 
 		return RangerResponse.ok(responses);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/review/application/ReviewService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/application/ReviewService.java
@@ -19,6 +19,7 @@ import com.devcourse.ReviewRanger.question.application.QuestionService;
 import com.devcourse.ReviewRanger.question.dto.response.GetQuestionResponse;
 import com.devcourse.ReviewRanger.review.domain.Review;
 import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
+import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailFirstResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewResponse;
 import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
@@ -72,14 +73,24 @@ public class ReviewService {
 	public GetReviewDetailResponse getReviewDetailOrThrow(Long reviewId) {
 		Review review = reviewRepository.findById(reviewId)
 			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
-		List<GetQuestionResponse> questionResponse = questionService.getAllQuestionsByReview(reviewId);
+		List<GetQuestionResponse> questionResponses = questionService.getAllQuestionsByReview(reviewId);
 
-		return new GetReviewDetailResponse(review, questionResponse);
+		return new GetReviewDetailResponse(review, questionResponses);
 	}
 
-	public List<GetUserResponse> getAllReceivers(Long reviewId, Long id) {
+	public GetReviewDetailFirstResponse getReviewDetailFirstOrThrow(Long reviewId, Long responserId) {
+		Review review = reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
+		List<GetQuestionResponse> questionResponses = questionService.getAllQuestionsByReview(reviewId);
+
+		List<GetUserResponse> receiverResponses = getAllReceivers(reviewId, responserId);
+
+		return new GetReviewDetailFirstResponse(review, questionResponses, receiverResponses);
+	}
+
+	public List<GetUserResponse> getAllReceivers(Long reviewId, Long responserId) {
 		return participationService.getAllByReviewId(reviewId).stream()
-			.filter(participation -> participation.getResponserId() != id)
+			.filter(participation -> participation.getResponserId() != responserId)
 			.map(participation -> userService.getUserOrThrow(participation.getResponserId()))
 			.map(user -> new GetUserResponse(user.getId(), user.getName()))
 			.toList();
@@ -93,4 +104,5 @@ public class ReviewService {
 
 		participationService.closeParticipationOrThrow(reviewId);
 	}
+
 }

--- a/src/main/java/com/devcourse/ReviewRanger/review/application/ReviewService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/application/ReviewService.java
@@ -4,17 +4,13 @@ import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
-
-import javax.persistence.EntityNotFoundException;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devcourse.ReviewRanger.common.exception.RangerException;
 import com.devcourse.ReviewRanger.participation.application.ParticipationService;
 import com.devcourse.ReviewRanger.participation.domain.DeadlineStatus;
-import com.devcourse.ReviewRanger.participation.domain.Participation;
+
 import com.devcourse.ReviewRanger.question.application.QuestionService;
 import com.devcourse.ReviewRanger.question.dto.response.GetQuestionResponse;
 import com.devcourse.ReviewRanger.review.domain.Review;
@@ -104,5 +100,4 @@ public class ReviewService {
 
 		participationService.closeParticipationOrThrow(reviewId);
 	}
-
 }

--- a/src/main/java/com/devcourse/ReviewRanger/review/dto/response/GetReviewDetailFirstResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/dto/response/GetReviewDetailFirstResponse.java
@@ -3,14 +3,14 @@ package com.devcourse.ReviewRanger.review.dto.response;
 import java.util.List;
 
 import com.devcourse.ReviewRanger.participation.domain.DeadlineStatus;
-
 import com.devcourse.ReviewRanger.question.dto.response.GetQuestionResponse;
 import com.devcourse.ReviewRanger.review.domain.Review;
+import com.devcourse.ReviewRanger.user.dto.GetUserResponse;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
-@Schema(description = "리뷰 상세 조회 응답 DTO")
-public record GetReviewDetailResponse(
+@Schema(description = "리뷰 상세 첫 조회 응답 DTO")
+public record GetReviewDetailFirstResponse(
 	@Schema(description = "리뷰 고유 id")
 	Long id,
 
@@ -24,15 +24,23 @@ public record GetReviewDetailResponse(
 	DeadlineStatus status,
 
 	@Schema(description = "리뷰에 포함된 질문 목록")
-	List<GetQuestionResponse> questions
+	List<GetQuestionResponse> questions,
+
+	@Schema(description = "응답자를 제외한 전체 리뷰 대상 목록")
+	List<GetUserResponse> receivers
 ) {
-	public GetReviewDetailResponse(Review review, List<GetQuestionResponse> questions) {
+	public GetReviewDetailFirstResponse(
+		Review review,
+		List<GetQuestionResponse> questions,
+		List<GetUserResponse> receivers
+	) {
 		this(
 			review.getId(),
 			review.getTitle(),
 			review.getDescription(),
 			review.getStatus(),
-			questions
+			questions,
+			receivers
 		);
 	}
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 프론트 담당자 분과 논의 후 초대 받은 리뷰 첫 조회시 리뷰, 질문, 리뷰 대상 정보 제공 api를 구현했습니다.
- 초대받은 리뷰 조회시 자신을 제외한 피어리뷰 대상자 전체조회 api를 구현했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 마감일정을 고려해 화면에 필요한 기능을 위한 api입니다.
- 해당 api를 사용한뒤 점차 분리하는 방향으로 진행해보려합니다.
- 피어리뷰 대상자 전체조회도 추후 분리를 계획해서 같이 구현했습니다.
- 현재는 피어리뷰 대상자중 자신을 걸러서 제공하지만 이 기능도 제외한 전체 조회로 변경할 계획이 있습니다.
- 브랜치명은 다음 pr부터 이슈번호만으로 올리겠습니다.


