### PR TITLE
[REV-179] 생성한 최종 리뷰 결과 리뷰대상에게 전송 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -19,19 +19,19 @@ public enum ErrorCode {
 
 	// 404 error
 	FAIL_USER_LOGIN(NOT_FOUND, "존재하지 않는 계정입니다."),
-
-	// 409 error
-	EXIST_SAME_NAME(CONFLICT, "이미 사용중인 이름 입니다."),
-	EXIST_SAME_EMAIL(CONFLICT, "이미 사용중인 이메일 입니다."),
-
-	//404 error
 	NOT_FOUND_USER(NOT_FOUND, "존재하지 않는 사용자입니다."),
 	NOT_FOUND_REVIEW(NOT_FOUND, "존재하지 않는 리뷰입니다."),
 	NOT_FOUND_QUESTION(NOT_FOUND, "존재하지 않는 질문입니다."),
 	NOT_FOUND_PARTICIPATION(NOT_FOUND, "해당하는 리뷰가 없습니다."),
 	NOT_FOUND_REVIEW_TARGET(NOT_FOUND, "존재하지 않는 리뷰 대상입니다."),
 	NOT_FOUND_REPLY(NOT_FOUND, "존재하지 않는 답변입니다."),
-	NOT_FOUND_QUESTION_TYPE(NOT_FOUND, "존재하지 않는 질문 타입입니다.");
+	NOT_FOUND_QUESTION_TYPE(NOT_FOUND, "존재하지 않는 질문 타입입니다."),
+	NOT_FOUND_FINAL_REVIEW_RESULT(NOT_FOUND, "존재하지 않는 최종 리뷰 결과입니다."),
+	NOT_FOUND_PARTICIPANTS(NOT_FOUND, "참여 목록이 존재하지 않습니다."),
+
+	// 409 error
+	EXIST_SAME_NAME(CONFLICT, "이미 사용중인 이름 입니다."),
+	EXIST_SAME_EMAIL(CONFLICT, "이미 사용중인 이메일 입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
@@ -64,4 +64,13 @@ public class FinalReviewResultController {
 		return RangerResponse.ok(checkStatus);
 	}
 
+	@PostMapping("/{reviewId}")
+	@ResponseStatus(OK)
+	public RangerResponse<Void> sendFinalResultToUsers(
+		@PathVariable Long reviewId
+	) {
+		finalReviewResultService.sendFinalResultToUsers(reviewId);
+
+		return RangerResponse.noData();
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
@@ -11,6 +11,7 @@ import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.Table;
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import com.devcourse.ReviewRanger.BaseEntity;
@@ -28,14 +29,14 @@ public class FinalReviewResult extends BaseEntity {
 	}
 
 	@Column(name = "user_id", nullable = false)
-	@NotBlank(message = "리뷰 대상 id는 빈값 일 수 없습니다.")
+	@NotNull(message = "리뷰 대상 id는 빈값 일 수 없습니다.")
 	private Long userId;
 
 	@Column(name = "user_name", nullable = false)
 	private String userName;
 
 	@Column(name = "review_id", nullable = false)
-	@NotBlank(message = "리뷰 id는 빈값 일 수 없습니다.")
+	@NotNull(message = "리뷰 id는 빈값 일 수 없습니다.")
 	private Long reviewId;
 
 	@Column(nullable = false, length = 50)

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/FinalReviewResultRepository.java
@@ -3,6 +3,7 @@ package com.devcourse.ReviewRanger.finalReviewResult.repository;
 import static com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResult.*;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -12,4 +13,6 @@ public interface FinalReviewResultRepository extends JpaRepository<FinalReviewRe
 	List<FinalReviewResult> findAllByUserIdAndStatus(Long userId, Status status);
 
 	List<FinalReviewResult> findAllByReviewIdAndStatus(Long reviewId, Status status);
+
+	Optional<FinalReviewResult> findByReviewIdAndUserIdAndStatus(Long reviewId, Long userId, Status status);
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 전송 버튼의 전송 기능을 추가했습니다.
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/add878d0-91cb-4640-b46d-bec37084da8b)
- 프론트에게서 받아오는 요청값 없이 테이블에서 리뷰 수신자를 탐색하여 전송합니다.
- 이미 보내진 최종 결과는 제외합니다.
- 트랜잭션이 걸려있어 모두 전송되거나 모두 전송되지 않거나로 작동합니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- ErrorCode 부분을 정리했습니다! (404는 모으고 에러 코드를 오름차순으로 정렬)
- controller 스웨거는 최종 리뷰 api를 전부 다 구현하고 (다음 PR이 마지막 구현) 함께 올리겠습니다!

![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/002355d3-b549-45e8-a8b9-37dbd428d8b4)



