### PR TITLE
[REV-230] 리뷰를 받은 수신자 조회 기능 검색 및 정렬 기능 동적 쿼리 구현

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
@@ -20,7 +20,6 @@ import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
 import com.devcourse.ReviewRanger.reply.application.ReplyService;
 import com.devcourse.ReviewRanger.reply.dto.response.ReplyResponse;
 import com.devcourse.ReviewRanger.user.domain.User;
-import com.devcourse.ReviewRanger.user.dto.UserResponse;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
 @Service
@@ -44,7 +43,13 @@ public class ReplyTargetService {
 	public void createReviewTarget(Long participationId,
 		List<CreateReplyTargetRequest> createReplyTargetRequests) {
 		for (CreateReplyTargetRequest createReplyTargetRequest : createReplyTargetRequests) {
-			ReplyTarget replyTarget = createReplyTargetRequest.toEntity();
+			User receiver = userRepository.findById(createReplyTargetRequest.receiverId())
+				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
+
+			User responer = userRepository.findById(createReplyTargetRequest.responserId())
+				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
+
+			ReplyTarget replyTarget = createReplyTargetRequest.toEntity(receiver, responer);
 			replyTarget.setParticipationId(participationId);
 
 			ReplyTarget savedReplyTarget = replyTargetRepository.save(replyTarget);
@@ -78,16 +83,7 @@ public class ReplyTargetService {
 		List<ReplyTargetResponse> responses = new ArrayList<>();
 
 		for (ReplyTarget replyTarget : replyTargets) {
-			User receiver = userRepository.findById(replyTarget.getReceiverId())
-				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
-			UserResponse receiverResponse = UserResponse.toResponse(receiver);
-
-			User responser = userRepository.findById(replyTarget.getResponserId())
-				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
-			UserResponse responserResponse = UserResponse.toResponse(responser);
-
-			ReplyTargetResponse replyTargetResponse = ReplyTargetResponse.toResponse(replyTarget,
-				receiverResponse, responserResponse);
+			ReplyTargetResponse replyTargetResponse = ReplyTargetResponse.toResponse(replyTarget);
 
 			List<ReplyResponse> replyResponses = getAllReplies(replyTarget);
 

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
@@ -43,8 +43,7 @@ public class ReplyTarget extends BaseEntity {
 	}
 
 	public ReplyTarget(User receiver, User responser) {
-		this.receiver = receiver;
-		this.responser = responser;
+		this(receiver, responser, null);
 	}
 
 	public ReplyTarget(User receiver, User responser, Long participationId) {

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
@@ -5,11 +5,15 @@ import java.util.List;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
 import javax.persistence.OneToMany;
 import javax.persistence.Table;
 
 import com.devcourse.ReviewRanger.BaseEntity;
 import com.devcourse.ReviewRanger.reply.domain.Reply;
+import com.devcourse.ReviewRanger.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonIdentityInfo;
 import com.fasterxml.jackson.annotation.ObjectIdGenerators;
 
@@ -21,11 +25,13 @@ import lombok.Getter;
 @JsonIdentityInfo(generator = ObjectIdGenerators.IntSequenceGenerator.class, property = "id")
 public class ReplyTarget extends BaseEntity {
 
-	@Column(name = "receiver_id", nullable = false)
-	private Long receiverId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "receiver_id", nullable = false)
+	private User receiver;
 
-	@Column(name = "responser_id", nullable = false)
-	private Long responserId;
+	@ManyToOne(fetch = FetchType.LAZY)
+	@JoinColumn(name = "responser_id", nullable = false)
+	private User responser;
 
 	@Column(name = "participation_id", nullable = false)
 	private Long participationId;
@@ -36,9 +42,15 @@ public class ReplyTarget extends BaseEntity {
 	protected ReplyTarget() {
 	}
 
-	public ReplyTarget(Long receiverId, Long responserId) {
-		this.receiverId = receiverId;
-		this.responserId = responserId;
+	public ReplyTarget(User receiver, User responser) {
+		this.receiver = receiver;
+		this.responser = responser;
+	}
+
+	public ReplyTarget(User receiver, User responser, Long participationId) {
+		this.receiver = receiver;
+		this.responser = responser;
+		this.participationId = participationId;
 	}
 
 	public void setParticipationId(Long participationId) {

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/dto/request/CreateReplyTargetRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/dto/request/CreateReplyTargetRequest.java
@@ -6,6 +6,7 @@ import javax.validation.constraints.NotNull;
 
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 import com.devcourse.ReviewRanger.reply.dto.request.CreateReplyRequest;
+import com.devcourse.ReviewRanger.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -24,7 +25,7 @@ public record CreateReplyTargetRequest(
 	@JsonProperty("replies")
 	List<CreateReplyRequest> createReplyRequests
 ) {
-	public ReplyTarget toEntity() {
-		return new ReplyTarget(receiverId, responserId);
+	public ReplyTarget toEntity(User receiver, User Responer) {
+		return new ReplyTarget(receiver, Responer);
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/dto/response/ReplyTargetResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/dto/response/ReplyTargetResponse.java
@@ -33,12 +33,11 @@ public record ReplyTargetResponse(
 	@Schema(description = "수정일")
 	LocalDateTime updatedAt
 ) {
-	public static ReplyTargetResponse toResponse(ReplyTarget replyTarget, UserResponse receiver,
-		UserResponse responer) {
+	public static ReplyTargetResponse toResponse(ReplyTarget replyTarget) {
 		return new ReplyTargetResponse(
 			replyTarget.getId(),
-			receiver,
-			responer,
+			UserResponse.toResponse(replyTarget.getReceiver()),
+			UserResponse.toResponse(replyTarget.getResponser()),
 			replyTarget.getParticipationId(),
 			new ArrayList<>(),
 			replyTarget.getCreateAt(),

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepository.java
@@ -5,5 +5,5 @@ import java.util.List;
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 
 public interface ReplyTargetCustomRepository {
-	List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName, String sort);
+	List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepository.java
@@ -1,0 +1,9 @@
+package com.devcourse.ReviewRanger.ReplyTarget.repository;
+
+import java.util.List;
+
+import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
+
+public interface ReplyTargetCustomRepository {
+	List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName, String sort);
+}

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
@@ -1,10 +1,11 @@
 package com.devcourse.ReviewRanger.ReplyTarget.repository;
 
+import static com.devcourse.ReviewRanger.ReplyTarget.domain.QReplyTarget.*;
+
 import java.util.List;
 
 import org.springframework.util.StringUtils;
 
-import com.devcourse.ReviewRanger.ReplyTarget.domain.QReplyTarget;
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
@@ -12,8 +13,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomRepository {
 
 	private final JPAQueryFactory jpaQueryFactory;
-
-	QReplyTarget qReplyTarget = QReplyTarget.replyTarget;
 
 	public ReplyTargetCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
 		this.jpaQueryFactory = jpaQueryFactory;
@@ -23,16 +22,16 @@ public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomReposit
 	public List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName) {
 		BooleanBuilder builder = new BooleanBuilder();
 		if (participationId != null) {
-			builder.and(qReplyTarget.participationId.eq(participationId));
+			builder.and(replyTarget.participationId.eq(participationId));
 		}
 
 		if (StringUtils.hasText(searchName)) {
-			builder.and(qReplyTarget.receiver.name.contains(searchName));
+			builder.and(replyTarget.receiver.name.contains(searchName));
 		}
 
-		List<ReplyTarget> replyTargets = jpaQueryFactory.selectFrom(qReplyTarget)
+		List<ReplyTarget> replyTargets = jpaQueryFactory.selectFrom(replyTarget)
 			.where(builder)
-			.orderBy(qReplyTarget.receiver.name.asc())
+			.orderBy(replyTarget.receiver.name.asc())
 			.fetch();
 
 		return replyTargets;

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
@@ -7,13 +7,9 @@ import org.springframework.util.StringUtils;
 import com.devcourse.ReviewRanger.ReplyTarget.domain.QReplyTarget;
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Order;
-import com.querydsl.core.types.OrderSpecifier;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomRepository {
-
-	private static final String RECEIVER_NAME = "receiverName";
 
 	private final JPAQueryFactory jpaQueryFactory;
 
@@ -24,7 +20,7 @@ public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomReposit
 	}
 
 	@Override
-	public List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName, String sort) {
+	public List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName) {
 		BooleanBuilder builder = new BooleanBuilder();
 		if (participationId != null) {
 			builder.and(qReplyTarget.participationId.eq(participationId));
@@ -36,22 +32,9 @@ public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomReposit
 
 		List<ReplyTarget> replyTargets = jpaQueryFactory.selectFrom(qReplyTarget)
 			.where(builder)
-			.orderBy(makeOrdersSpecifiers(sort))
+			.orderBy(qReplyTarget.receiver.name.asc())
 			.fetch();
 
 		return replyTargets;
 	}
-
-	private OrderSpecifier<?> makeOrdersSpecifiers(String sort) {
-		if (sort == null) {
-			return new OrderSpecifier(Order.ASC, qReplyTarget.receiver.name);
-		}
-
-		if (sort.equalsIgnoreCase(RECEIVER_NAME)) {
-			return new OrderSpecifier(Order.DESC, qReplyTarget.receiver.name);
-		}
-
-		return null;
-	}
-
 }

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetCustomRepositoryImpl.java
@@ -1,0 +1,57 @@
+package com.devcourse.ReviewRanger.ReplyTarget.repository;
+
+import java.util.List;
+
+import org.springframework.util.StringUtils;
+
+import com.devcourse.ReviewRanger.ReplyTarget.domain.QReplyTarget;
+import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.Order;
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+public class ReplyTargetCustomRepositoryImpl implements ReplyTargetCustomRepository {
+
+	private static final String RECEIVER_NAME = "receiverName";
+
+	private final JPAQueryFactory jpaQueryFactory;
+
+	QReplyTarget qReplyTarget = QReplyTarget.replyTarget;
+
+	public ReplyTargetCustomRepositoryImpl(JPAQueryFactory jpaQueryFactory) {
+		this.jpaQueryFactory = jpaQueryFactory;
+	}
+
+	@Override
+	public List<ReplyTarget> findAllByParticipationIdToDynamic(Long participationId, String searchName, String sort) {
+		BooleanBuilder builder = new BooleanBuilder();
+		if (participationId != null) {
+			builder.and(qReplyTarget.participationId.eq(participationId));
+		}
+
+		if (StringUtils.hasText(searchName)) {
+			builder.and(qReplyTarget.receiver.name.contains(searchName));
+		}
+
+		List<ReplyTarget> replyTargets = jpaQueryFactory.selectFrom(qReplyTarget)
+			.where(builder)
+			.orderBy(makeOrdersSpecifiers(sort))
+			.fetch();
+
+		return replyTargets;
+	}
+
+	private OrderSpecifier<?> makeOrdersSpecifiers(String sort) {
+		if (sort == null) {
+			return new OrderSpecifier(Order.ASC, qReplyTarget.receiver.name);
+		}
+
+		if (sort.equalsIgnoreCase(RECEIVER_NAME)) {
+			return new OrderSpecifier(Order.DESC, qReplyTarget.receiver.name);
+		}
+
+		return null;
+	}
+
+}

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 
-public interface ReplyTargetRepository extends JpaRepository<ReplyTarget, Long> {
+public interface ReplyTargetRepository extends JpaRepository<ReplyTarget, Long>, ReplyTargetCustomRepository {
 	List<ReplyTarget> findAllByParticipationId(Long participationId);
 
 	List<ReplyTarget> findAllByReceiverId(Long receiverId);

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -175,8 +175,7 @@ public class FinalReviewResultService {
 			List<ReplyTarget> replyTargets = replyTargetRepository.findAllByParticipationId(participationId);
 
 			for (ReplyTarget replyTarget : replyTargets) {
-				Long receiverId = replyTarget.getReceiverId();
-				userIds.add(receiverId);
+				userIds.add(replyTarget.getReceiver().getId());
 			}
 		}
 

--- a/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
@@ -52,8 +52,7 @@ public class ParticipationController {
 	@Tag(name = "participation")
 	@Operation(summary = "[토큰] 리뷰 답변 기능", description = "[토큰] 리뷰 답변 API", responses = {
 		@ApiResponse(responseCode = "201", description = "리뷰 답변 성공"),
-		@ApiResponse(responseCode = "404", description = "참여자로 존재하지 않는 경우"),
-
+		@ApiResponse(responseCode = "404", description = "사용자가 존재하지 않는 경우")
 	})
 	@ResponseStatus(CREATED)
 	@PostMapping(value = "/participations")
@@ -66,8 +65,7 @@ public class ParticipationController {
 	@Tag(name = "participation")
 	@Operation(summary = "[토큰] 리뷰 답변 수정 기능", description = "[토큰] 리뷰 답변 수정 API", responses = {
 		@ApiResponse(responseCode = "200", description = "리뷰 답변 수정 성공"),
-		@ApiResponse(responseCode = "404", description = "답변이 존재하지 않는 경우"),
-
+		@ApiResponse(responseCode = "404", description = "답변이 존재하지 않는 경우")
 	})
 	@PutMapping(value = "/participations")
 	public RangerResponse<Void> updateParticipation(@RequestBody @Valid UpdateParticipationRequest request) {

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -115,7 +115,7 @@ public class ParticipationService {
 		return responses;
 	}
 
-	public List<ReceiverResponse> getAllReceiver(Long reviewId, String searchName, String sort) {
+	public List<ReceiverResponse> getAllReceiver(Long reviewId, String searchName) {
 		List<ReceiverResponse> responses = new ArrayList<>();
 		Map<User, Integer> receiverToResponserCountsMap = new LinkedHashMap<>();
 
@@ -123,7 +123,7 @@ public class ParticipationService {
 
 		for (Participation participation : participations) {
 			List<ReplyTarget> replyTargets = replyTargetRepository.findAllByParticipationIdToDynamic(
-				participation.getId(), searchName, sort);
+				participation.getId(), searchName);
 
 			for (ReplyTarget replyTarget : replyTargets) {
 				receiverToResponserCountsMap.put(replyTarget.getReceiver(),

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -122,7 +122,7 @@ public class ParticipationService {
 			List<ReplyTarget> replyTargets = replyTargetService.getAllByParticipationId(participation.getId());
 
 			for (ReplyTarget replyTarget : replyTargets) {
-				Long receiverId = replyTarget.getReceiverId();
+				Long receiverId = replyTarget.getReceiver().getId();
 				receiverToResponsersMap.put(receiverId, receiverToResponsersMap.getOrDefault(receiverId, 0) + 1);
 			}
 		}

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -3,7 +3,7 @@ package com.devcourse.ReviewRanger.participation.application;
 import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.devcourse.ReviewRanger.ReplyTarget.application.ReplyTargetService;
 import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
+import com.devcourse.ReviewRanger.ReplyTarget.repository.ReplyTargetRepository;
 import com.devcourse.ReviewRanger.common.exception.RangerException;
 import com.devcourse.ReviewRanger.participation.domain.Participation;
 import com.devcourse.ReviewRanger.participation.domain.ReviewStatus;
@@ -36,14 +37,17 @@ public class ParticipationService {
 	private final UserRepository userRepository;
 	private final ReviewRepository reviewRepository;
 	private final ReplyTargetService replyTargetService;
+	private final ReplyTargetRepository replyTargetRepository;
 
 	public ParticipationService(ParticipationRepository participationRepository,
 		UserRepository userRepository,
-		ReviewRepository reviewRepository, ReplyTargetService replyTargetService) {
+		ReviewRepository reviewRepository, ReplyTargetService replyTargetService,
+		ReplyTargetRepository replyTargetRepository) {
 		this.participationRepository = participationRepository;
 		this.userRepository = userRepository;
 		this.reviewRepository = reviewRepository;
 		this.replyTargetService = replyTargetService;
+		this.replyTargetRepository = replyTargetRepository;
 	}
 
 	@Transactional
@@ -94,7 +98,7 @@ public class ParticipationService {
 		participations.stream().forEach(participation -> participation.changeStatus(ReviewStatus.END));
 	}
 
-	public List<ParticipationResponse> getAllParticipation(Long reviewId, String name, String sort) {
+	public List<ParticipationResponse> getAllParticipationOrThrow(Long reviewId, String name, String sort) {
 		Review review = reviewRepository.findById(reviewId)
 			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
 		User creator = userRepository.findById(review.getRequesterId())
@@ -111,27 +115,24 @@ public class ParticipationService {
 		return responses;
 	}
 
-	public List<ReceiverResponse> getAllReceiverParticipateInReviewOrThrow(Long reviewId, String searchName,
-		String sortCondition) {
+	public List<ReceiverResponse> getAllReceiver(Long reviewId, String searchName, String sort) {
 		List<ReceiverResponse> responses = new ArrayList<>();
-		Map<Long, Integer> receiverToResponsersMap = new HashMap<>();
+		Map<User, Integer> receiverToResponserCountsMap = new LinkedHashMap<>();
 
-		List<Participation> participations = getAllByReviewId(reviewId);
+		List<Participation> participations = participationRepository.findByReviewId(reviewId);
 
 		for (Participation participation : participations) {
-			List<ReplyTarget> replyTargets = replyTargetService.getAllByParticipationId(participation.getId());
+			List<ReplyTarget> replyTargets = replyTargetRepository.findAllByParticipationIdToDynamic(
+				participation.getId(), searchName, sort);
 
 			for (ReplyTarget replyTarget : replyTargets) {
-				Long receiverId = replyTarget.getReceiver().getId();
-				receiverToResponsersMap.put(receiverId, receiverToResponsersMap.getOrDefault(receiverId, 0) + 1);
+				receiverToResponserCountsMap.put(replyTarget.getReceiver(),
+					receiverToResponserCountsMap.getOrDefault(replyTarget.getReceiver(), 0) + 1);
 			}
 		}
 
-		for (Map.Entry<Long, Integer> receiver : receiverToResponsersMap.entrySet()) {
-			User user = userRepository.findById(receiver.getKey())
-				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
-
-			ReceiverResponse response = new ReceiverResponse(receiver.getKey(), user.getName(),
+		for (Map.Entry<User, Integer> receiver : receiverToResponserCountsMap.entrySet()) {
+			ReceiverResponse response = new ReceiverResponse(receiver.getKey().getId(), receiver.getKey().getName(),
 				receiver.getValue());
 
 			responses.add(response);

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -145,9 +145,8 @@ public class ReviewController {
 	@GetMapping("/reviews/{id}/receiver")
 	public RangerResponse<List<ReceiverResponse>> getAllReceiverParticipateInReview(
 		@PathVariable Long id,
-		@RequestParam(value = "searchName", required = false) String searchName,
-		@RequestParam(value = "sort", required = false) String sort) {
-		List<ReceiverResponse> response = participationService.getAllReceiver(id, searchName, sort);
+		@RequestParam(value = "searchName", required = false) String searchName) {
+		List<ReceiverResponse> response = participationService.getAllReceiver(id, searchName);
 
 		return RangerResponse.ok(response);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -133,23 +133,21 @@ public class ReviewController {
 		@RequestParam(value = "searchName", required = false) String searchName,
 		@RequestParam(value = "sort", required = false) String sort
 	) {
-		List<ParticipationResponse> response = participationService.getAllParticipation(id, searchName, sort);
+		List<ParticipationResponse> response = participationService.getAllParticipationOrThrow(id, searchName, sort);
 
 		return RangerResponse.ok(response);
 	}
 
 	@Tag(name = "review")
 	@Operation(summary = "[토큰] 리뷰를 받은 모든 수신자 조회", description = "[토큰] 리뷰를 받은 모든 수신자 조회 API", responses = {
-		@ApiResponse(responseCode = "200", description = "리뷰를 받은 모든 수신자 조회 성공"),
-		@ApiResponse(responseCode = "404", description = "사용자 존재하지 않는 경우")
+		@ApiResponse(responseCode = "200", description = "리뷰를 받은 모든 수신자 조회 성공")
 	})
 	@GetMapping("/reviews/{id}/receiver")
 	public RangerResponse<List<ReceiverResponse>> getAllReceiverParticipateInReview(
 		@PathVariable Long id,
 		@RequestParam(value = "searchName", required = false) String searchName,
 		@RequestParam(value = "sort", required = false) String sort) {
-		List<ReceiverResponse> response = participationService.getAllReceiverParticipateInReviewOrThrow(
-			id, searchName, sort);
+		List<ReceiverResponse> response = participationService.getAllReceiver(id, searchName, sort);
 
 		return RangerResponse.ok(response);
 	}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 답변 타겟의 수신자 <-> 유저 `@ManyToOne` 단방향 매핑
- 답변 타겟의 응답자 <-> 유저 `@ManyToOne` 단방향 매핑
- 리뷰를 받은 수신자를 조회하는 기능에서 수신자 이름 검색 기능을 동적 쿼리로 구현하였습니다.

### 예시 쿼리
- 디폴트 : 수신자 이름 오름차순

```json
select
        replyTarget 
    from
        ReplyTarget replyTarget   
    left join
        replyTarget.receiver as replyTarget_receiver 
    where
        replyTarget.participationId = ?1 
    order by
        replyTarget_receiver.name asc
```

- searchName=가가 : 이름에 가가가 들어간 이름 찾기 & 수신자 이름 오름차순

```json
select
        replyTarget 
    from
        ReplyTarget replyTarget 
    where
        replyTarget.participationId = ?1 
        and replyTarget.receiver.name like ?2 escape '!' 
    order by
        replyTarget.receiver.name asc
```

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 유저와의 단방향 매핑을 맺은 이유
  - 수신자와 응답자를 반환해야 하는 경우 id뿐만 아니라 이름을 같이 반환해야 하기 때문에 필요하다고 느꼈습니다.
  - 답변을 전송할 당시에 프론트에서 수신자와 응답자의 Id 값을 받아오는데 이를 검증해야 하고 이 값을 알맞게 사용할 수 있다고 느꼈습니다.
  - 동적 쿼리 구현은 이전 PR와 거의 유사합니다.