### PR TITLE
[REV-225] 슬랙봇 서비스 초안 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -61,6 +61,11 @@ dependencies {
     // query dsl
     implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
     annotationProcessor "com.querydsl:querydsl-apt:${queryDslVersion}"
+
+    // slack
+    implementation "com.slack.api:bolt:1.18.0"
+    implementation "com.slack.api:bolt-servlet:1.18.0"
+    implementation "com.slack.api:bolt-jetty:1.18.0"
 }
 
 tasks.named('test') {

--- a/src/main/java/com/devcourse/ReviewRanger/ReviewRangerApplication.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReviewRangerApplication.java
@@ -3,10 +3,12 @@ package com.devcourse.ReviewRanger;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 
 @EnableJpaAuditing
 @EnableWebSecurity
+@EnableAsync
 @SpringBootApplication
 public class ReviewRangerApplication {
 

--- a/src/main/java/com/devcourse/ReviewRanger/common/config/AsyncConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package com.devcourse.ReviewRanger.common.config;
+
+import java.util.concurrent.Executor;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig extends AsyncConfigurerSupport {
+
+	@Override
+	public Executor getAsyncExecutor() {
+		ThreadPoolTaskExecutor taskExecutor = new ThreadPoolTaskExecutor();
+		taskExecutor.setCorePoolSize(3);
+		taskExecutor.setMaxPoolSize(30);
+		taskExecutor.setQueueCapacity(50);
+		taskExecutor.initialize();
+		return taskExecutor;
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/participation/repository/ParticipationRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/repository/ParticipationRepository.java
@@ -15,4 +15,6 @@ public interface ParticipationRepository extends JpaRepository<Participation, Lo
 	Participation findByReviewIdAndResponserId(Long reviewId, Long responserId);
 
 	List<Participation> findAllByReviewId(Long reviewId);
+
+	List<Participation> findAllByReviewIdAndIsAnswered(Long reviewId, Boolean isAnswered);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/review/repository/ReviewRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/repository/ReviewRepository.java
@@ -1,13 +1,17 @@
 package com.devcourse.ReviewRanger.review.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.devcourse.ReviewRanger.participation.domain.ReviewStatus;
 import com.devcourse.ReviewRanger.review.domain.Review;
 
 public interface ReviewRepository extends
 	JpaRepository<Review, Long>, ReviewCustomRepository {
 
 	List<Review> findByRequesterId(Long requesterId);
+
+	Optional<Review> findByTitleAndStatusOrderByCreateAtDesc(String title, ReviewStatus status);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/slack/SlackConstant.java
+++ b/src/main/java/com/devcourse/ReviewRanger/slack/SlackConstant.java
@@ -1,0 +1,6 @@
+package com.devcourse.ReviewRanger.slack;
+
+class SlackConstant {
+
+	public static final String TEST = "슬랙봇-테스트";
+}

--- a/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
@@ -16,7 +16,7 @@ public class SlackController {
 	}
 
 	@PostMapping("/alert")
-	public void alertMessage(@RequestParam("text") String text) {
-		slackService.alertSlackMessage(text);
+	public void alertMessage(@RequestParam("title") String title) {
+		slackService.alertSlackMessage(title);
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
@@ -1,0 +1,22 @@
+package com.devcourse.ReviewRanger.slack;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/slack")
+public class SlackController {
+
+	private final SlackService slackService;
+
+	public SlackController(SlackService slackService) {
+		this.slackService = slackService;
+	}
+
+	@PostMapping("/alert")
+	public void alertMessage(@RequestParam("text") String text) {
+		slackService.alertSlackMessage(text);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/slack/SlackService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/slack/SlackService.java
@@ -1,0 +1,84 @@
+package com.devcourse.ReviewRanger.slack;
+
+import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
+import static com.devcourse.ReviewRanger.participation.domain.ReviewStatus.*;
+import static com.devcourse.ReviewRanger.slack.SlackConstant.*;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.common.exception.RangerException;
+import com.devcourse.ReviewRanger.participation.domain.Participation;
+import com.devcourse.ReviewRanger.participation.repository.ParticipationRepository;
+import com.devcourse.ReviewRanger.review.domain.Review;
+import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.slack.api.Slack;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+
+@Service
+@Transactional(readOnly = true)
+public class SlackService {
+
+	@Value(value = "${slack.token}")
+	private String slackToken;
+
+	private final ParticipationRepository participationRepository;
+	private final ReviewRepository reviewRepository;
+
+	public SlackService(ParticipationRepository participationRepository, ReviewRepository reviewRepository) {
+		this.participationRepository = participationRepository;
+		this.reviewRepository = reviewRepository;
+	}
+
+	public void sendSlackMessage(String message) {
+		try {
+			MethodsClient methods = Slack.getInstance().methods(slackToken);
+			methods.chatPostMessage(req -> req.channel(TEST).text(message));
+		} catch (SlackApiException | IOException e) {
+			throw new RuntimeException(e);
+		}
+	}
+
+	@Async
+	@Transactional
+	public void alertSlackMessage(String title) {
+		Review review = reviewRepository.findByTitleAndStatusOrderByCreateAtDesc(title, PROCEEDING)
+			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
+
+		List<Participation> notAnswerResponsers
+			= participationRepository.findAllByReviewIdAndIsAnswered(review.getId(), false);
+
+		LocalDateTime reviewCloseTime = review.getClosedAt();
+		LocalDateTime currentTime = LocalDateTime.now();
+		long remainingTime = ChronoUnit.DAYS.between(currentTime, reviewCloseTime);
+
+		StringBuilder message = new StringBuilder("피어리뷰 기간이 " + remainingTime + "일 남았습니다. ");
+		message.append("마감일은 ").append(reviewCloseTime.toLocalDate()).append("입니다. \n");
+
+		for (int i = 0; i < notAnswerResponsers.size(); i++) {
+			Participation participation = notAnswerResponsers.get(i);
+			User responser = participation.getResponser();
+
+			String responserName = responser.getName();
+			message.append("\"").append(responserName).append("\"");
+
+			if (i == notAnswerResponsers.size() - 1) {
+				message.append("님 ");
+			} else {
+				message.append("님, ");
+			}
+		}
+		message.append("피어리뷰를 완료해 주세요!! 😆🥺");
+
+		sendSlackMessage(message.toString());
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- Slack에 Bot을 생성하여 피어리뷰 마감 기한과 작성하지 않은 사람들을 호출하는 Bot 초안을 구현하였습니다.
- 슬랙봇 서비스가 저희 서버와 동기적으로 진행되는 것을 막기위해 비동기 처리 하였습니다.
<img width="558" alt="스크린샷 2023-11-19 오후 7 54 04" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/7fac1e08-a542-481c-ade6-8ec10d39a9d0">
<img width="481" alt="스크린샷 2023-11-19 오후 7 54 44" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/9d7c9fc8-4893-4930-a767-3394a991e235">

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 호출되는 채널을 코드에서 직접 설정해야 하고 사용자를 멘션하기 위해서는 사용자들의 정보를 slack에서 받아와야 합니다. 상대적으로 중요도가 낮아지는 것 같아 후순위로 미루도록 하겠습니다.
- 사용자가 리뷰 식별자를 알 수 없으므로 리뷰 제목을 입력받고 해당 제목을 통해 진행중이면서 가장 최근인 review를 DB에서 가져오도록 하였습니다. 
