### PR TITLE
[REV-246] 수신자별 & 작성자별 전체 조회 테스트 구현

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/BaseEntity.java
+++ b/src/main/java/com/devcourse/ReviewRanger/BaseEntity.java
@@ -17,7 +17,6 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 
-
 import lombok.Getter;
 
 @Getter
@@ -38,4 +37,8 @@ public abstract class BaseEntity {
 	@Column(name = "updated_at")
 	@JsonFormat(shape = STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
 	private LocalDateTime updatedAt;
+
+	public void setId(Long id) {
+		this.id = id;
+	}
 }

--- a/src/test/java/com/devcourse/ReviewRanger/participation/application/ParticipationServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/participation/application/ParticipationServiceTest.java
@@ -3,6 +3,7 @@ package com.devcourse.ReviewRanger.participation.application;
 import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 import static org.mockito.BDDMockito.*;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.assertj.core.api.Assertions;
@@ -14,11 +15,17 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.devcourse.ReviewRanger.ReplyTarget.application.ReplyTargetService;
+import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 import com.devcourse.ReviewRanger.ReplyTarget.repository.ReplyTargetRepository;
 import com.devcourse.ReviewRanger.common.exception.RangerException;
 import com.devcourse.ReviewRanger.participation.domain.Participation;
 import com.devcourse.ReviewRanger.participation.dto.request.SubmitParticipationRequest;
+import com.devcourse.ReviewRanger.participation.dto.response.ParticipationResponse;
+import com.devcourse.ReviewRanger.participation.dto.response.ReceiverResponse;
 import com.devcourse.ReviewRanger.participation.repository.ParticipationRepository;
+import com.devcourse.ReviewRanger.review.domain.Review;
+import com.devcourse.ReviewRanger.review.domain.ReviewType;
+import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
 import com.devcourse.ReviewRanger.user.domain.User;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 import com.devcourse.ReviewRanger.user.service.UserFixture;
@@ -40,6 +47,9 @@ class ParticipationServiceTest {
 
 	@Mock
 	private ReplyTargetRepository replyTargetRepository;
+
+	@Mock
+	private ReviewRepository reviewRepository;
 
 	@Test
 	void 답변_참여_성공() {
@@ -69,5 +79,77 @@ class ParticipationServiceTest {
 		Assertions.assertThatThrownBy(() -> participationService.getByIdOrThrow(participationId))
 			.isInstanceOf(RangerException.class)
 			.hasMessage(NOT_FOUND_PARTICIPATION.getMessage());
+	}
+
+	@Test
+	void 전체_응답자_조회() {
+		//given
+		User user1 = UserFixture.SPENCER_FIXTURE.toEntity();
+		given(userRepository.findById(user1.getId())).willReturn(Optional.of(user1));
+
+		Review review = new Review("피어 리뷰", "설명", ReviewType.PEER_REVIEW);
+		review.setId(1L);
+		given(reviewRepository.findById(1L)).willReturn(Optional.of(review));
+
+		User suyeon = UserFixture.SUYEON_FIXTURE.toEntity();
+		User beomchul = UserFixture.BEOMCHUL_FIXTURE.toEntity();
+		User juwoong = UserFixture.JUWOONG_FIXTURE.toEntity();
+
+		Participation participation1 = new Participation(suyeon);
+		Participation participation2 = new Participation(beomchul);
+		Participation participation3 = new Participation(juwoong);
+
+		List<Participation> participations = List.of(participation1, participation2, participation3);
+
+		given(participationRepository.findAllByReviewIdToDynamic(1L, null,
+			null)).willReturn(participations);
+
+		//when
+		List<ParticipationResponse> responses = participationService.getAllParticipationOrThrow(1L, null,
+			null);
+
+		//then
+		Assertions.assertThat(responses.get(0).user().name()).isEqualTo("장수연");
+		Assertions.assertThat(responses.get(1).user().name()).isEqualTo("신범철");
+		Assertions.assertThat(responses.get(2).user().name()).isEqualTo("김주웅");
+		verify(participationRepository, times(1)).findAllByReviewIdToDynamic(1L, null, null);
+	}
+
+	@Test
+	void 전체_수신자_조회() {
+		//given
+		User suyeon = UserFixture.SUYEON_FIXTURE.toEntity();
+		User beomchul = UserFixture.BEOMCHUL_FIXTURE.toEntity();
+		User juwoong = UserFixture.JUWOONG_FIXTURE.toEntity();
+
+		Participation participation1 = new Participation(suyeon);
+		participation1.setId(1L);
+		Participation participation2 = new Participation(beomchul);
+		participation2.setId(2L);
+		Participation participation3 = new Participation(juwoong);
+		participation3.setId(3L);
+		participation1.answeredReview();
+
+		List<Participation> participations = List.of(participation1, participation2, participation3);
+
+		given(participationRepository.findByReviewId(1L)).willReturn(participations);
+
+		ReplyTarget replyTarget1 = new ReplyTarget(beomchul, suyeon, 1L);
+		ReplyTarget replyTarget2 = new ReplyTarget(juwoong, suyeon, 1L);
+
+		List<ReplyTarget> replyTargetList = List.of(replyTarget1, replyTarget2);
+
+		given(replyTargetRepository.findAllByParticipationIdToDynamic(1L, null)).willReturn(
+			replyTargetList);
+
+		//when
+		List<ReceiverResponse> responses = participationService.getAllReceiver(1L, null);
+
+		//then
+		System.out.println(responses);
+		Assertions.assertThat(responses.get(0).receiverName()).isEqualTo("신범철");
+		Assertions.assertThat(responses.get(1).receiverName()).isEqualTo("김주웅");
+		Assertions.assertThat(responses.get(0).responserCount()).isEqualTo(1);
+		verify(replyTargetRepository, times(1)).findAllByParticipationIdToDynamic(1L, null);
 	}
 }

--- a/src/test/java/com/devcourse/ReviewRanger/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/review/api/ReviewControllerTest.java
@@ -1,0 +1,115 @@
+package com.devcourse.ReviewRanger.review.api;
+
+import static java.time.LocalDateTime.*;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import com.devcourse.ReviewRanger.common.config.SecurityConfig;
+import com.devcourse.ReviewRanger.common.jwt.JwtTokenProvider;
+import com.devcourse.ReviewRanger.participation.application.ParticipationService;
+import com.devcourse.ReviewRanger.participation.domain.ReviewStatus;
+import com.devcourse.ReviewRanger.participation.dto.response.ParticipationResponse;
+import com.devcourse.ReviewRanger.participation.dto.response.ReceiverResponse;
+import com.devcourse.ReviewRanger.review.application.ReviewService;
+import com.devcourse.ReviewRanger.review.domain.ReviewType;
+import com.devcourse.ReviewRanger.review.dto.response.ReviewResponse;
+import com.devcourse.ReviewRanger.user.dto.UserResponse;
+
+@WebMvcTest(ReviewController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@Import(SecurityConfig.class)
+class ReviewControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	@MockBean
+	private ReviewService reviewService;
+
+	@MockBean
+	private ParticipationService participationService;
+
+	@Test
+	void 수신자_전체_조회() throws Exception {
+		ReceiverResponse 범철 = new ReceiverResponse(2L, "범철", 1);
+		ReceiverResponse 주웅 = new ReceiverResponse(3L, "주웅", 1);
+
+		List<ReceiverResponse> responses = List.of(범철, 주웅);
+
+		given(participationService.getAllReceiver(1L, null)).willReturn(responses);
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/reviews/{id}/receiver", 1L)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+
+	@Test
+	void 작성자_전체_조회() throws Exception {
+		LocalDateTime now = now();
+
+		UserResponse 스펜서 = new UserResponse(
+			3L,
+			"aaaatt33@naver.com",
+			"스펜서",
+			now,
+			now
+		);
+
+		ReviewResponse reviewResponse = new ReviewResponse(
+			1L,
+			스펜서,
+			"피어 리뷰",
+			"설명",
+			ReviewType.PEER_REVIEW,
+			now,
+			ReviewStatus.PROCEEDING,
+			now,
+			now
+		);
+
+		UserResponse 수연 = new UserResponse(
+			1L,
+			"aaaatt11@naver.com",
+			"수연",
+			now,
+			now
+		);
+
+		ParticipationResponse participationResponse = new ParticipationResponse(1L,
+			reviewResponse,
+			수연,
+			false,
+			ReviewStatus.PROCEEDING,
+			null,
+			now,
+			now
+		);
+
+		List<ParticipationResponse> responses = List.of(participationResponse);
+
+		given(participationService.getAllParticipationOrThrow(1L, null, null)).willReturn(responses);
+
+		mockMvc.perform(MockMvcRequestBuilders.get("/reviews/{id}/responser", 1L)
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andDo(print());
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 리뷰에 참여하는 인원 전체 조회 테스트, 리뷰를 받은 인원 전체 조회 테스트를 구현하였습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 사용자의 Id값이 계속 null이 발생해 setter을 넣어주었습니다.

