### PR TITLE
[REV-216] 리뷰 생성 테스트 코드 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ repositories {
 dependencies {
     // security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    testImplementation 'org.springframework.security:spring-security-test'
 
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'

--- a/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/question/application/QuestionServiceTest.java
@@ -1,0 +1,69 @@
+package com.devcourse.ReviewRanger.question.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.List;
+
+import javax.validation.ConstraintViolationException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import com.devcourse.ReviewRanger.question.domain.QuestionType;
+import com.devcourse.ReviewRanger.question.dto.request.CreateQuestionOptionRequest;
+import com.devcourse.ReviewRanger.question.dto.request.CreateQuestionRequest;
+
+@SpringBootTest
+class QuestionServiceTest {
+
+	@Autowired
+	QuestionService questionService;
+
+	@Test
+	void 질문_생성_성공() {
+		// given
+		String title = "질문 내용입니다.";
+		QuestionType type = QuestionType.SUBJECTIVE;
+		Boolean isRequired = true;
+		List<CreateQuestionOptionRequest> questionOptions = List.of();
+
+		CreateQuestionRequest createQuestionRequest = new CreateQuestionRequest(
+			title,
+			type,
+			isRequired,
+			questionOptions
+			);
+
+		Long reviewId = 1L;
+
+		// when
+		Boolean result = questionService.createQuestions(reviewId, List.of(createQuestionRequest));
+
+		// then
+		assertTrue(result);
+	}
+
+	@Test
+	void 질문제목_빈값에_따른_질문_생성_실패() {
+		// given
+		String title = "";
+		QuestionType type = QuestionType.SUBJECTIVE;
+		Boolean isRequired = true;
+		List<CreateQuestionOptionRequest> questionOptions = List.of();
+
+		CreateQuestionRequest createQuestionRequest = new CreateQuestionRequest(
+			title,
+			type,
+			isRequired,
+			questionOptions
+		);
+
+		Long reviewId = 1L;
+
+		// when then
+		assertThrows(ConstraintViolationException.class, ()->{
+			questionService.createQuestions(reviewId, List.of(createQuestionRequest));
+		});
+	}
+}

--- a/src/test/java/com/devcourse/ReviewRanger/review/api/ReviewControllerTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/review/api/ReviewControllerTest.java
@@ -1,0 +1,98 @@
+package com.devcourse.ReviewRanger.review.api;
+
+import static com.devcourse.ReviewRanger.user.service.TestPrincipalDetailsService.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
+import org.springframework.http.MediaType;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.test.web.servlet.MockMvc;
+
+import com.devcourse.ReviewRanger.user.service.TestPrincipalDetailsService;
+import com.devcourse.ReviewRanger.common.config.SecurityConfig;
+import com.devcourse.ReviewRanger.common.jwt.JwtTokenProvider;
+import com.devcourse.ReviewRanger.participation.application.ParticipationService;
+
+import com.devcourse.ReviewRanger.question.dto.request.CreateQuestionRequest;
+import com.devcourse.ReviewRanger.review.application.ReviewService;
+import com.devcourse.ReviewRanger.review.domain.ReviewType;
+import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@WebMvcTest(ReviewController.class)
+@MockBean(JpaMetamodelMappingContext.class)
+@Import(SecurityConfig.class)
+class ReviewControllerTest {
+
+	@Autowired
+	private MockMvc mvc;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
+	@MockBean
+	private ReviewService reviewService;
+
+	@MockBean
+	private ParticipationService participationService;
+
+	@MockBean
+	private JwtTokenProvider jwtTokenProvider;
+
+	private TestPrincipalDetailsService testUserDetailsService;
+	private UserDetails userDetails;
+
+	@BeforeEach
+	public void setUp(){
+		testUserDetailsService = new TestPrincipalDetailsService();
+		userDetails = testUserDetailsService.loadUserByUsername(USER_EMAIL);
+	}
+
+	@Test
+	void 리뷰_생성_성공() throws Exception {
+		// given
+		String title = "테스트 리뷰";
+		String description = "이 리뷰는 테스트입니다.";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		when(reviewService.createReview(null,createReviewRequest)).thenReturn(true);
+
+		// when
+		// then
+		mvc.perform(post("/reviews")
+				.content(objectMapper.writeValueAsString(createReviewRequest))
+				.with(user(userDetails))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andDo(print());
+
+		verify(reviewService, times(1)).createReview(null,createReviewRequest);
+	}
+}

--- a/src/test/java/com/devcourse/ReviewRanger/review/application/ReviewServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/review/application/ReviewServiceTest.java
@@ -1,0 +1,157 @@
+package com.devcourse.ReviewRanger.review.application;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import javax.validation.ConstraintViolationException;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.dao.DataIntegrityViolationException;
+
+import com.devcourse.ReviewRanger.question.dto.request.CreateQuestionRequest;
+import com.devcourse.ReviewRanger.review.domain.ReviewType;
+import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
+import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
+
+@SpringBootTest
+class ReviewServiceTest {
+
+	@Autowired
+	private ReviewService reviewService;
+
+	@Test
+	void 리뷰_생성_성공() {
+		// given
+		String title = "테스트 리뷰";
+		String description = "이 리뷰는 테스트입니다.";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		Long requesterId = 1L;
+
+		// when
+		boolean result = reviewService.createReview(requesterId, createReviewRequest);
+
+		// then
+		assertTrue(result);
+	}
+
+	@Test
+	void 리뷰제목_빈값에_따른_리뷰_생성_실패() {
+		// given
+		String title = "";
+		String description = "이 리뷰는 테스트입니다.";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		Long requesterId = 1L;
+
+		// when then
+		assertThrows(ConstraintViolationException.class, ()->{
+			reviewService.createReview(requesterId, createReviewRequest);
+		});
+	}
+
+	@Test
+	void 리뷰제목_50자_이상에_따른_리뷰_생성_실패() {
+		// given
+		String title = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+		String description = "이 리뷰는 테스트입니다.";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		Long requesterId = 1L;
+
+		// when then
+		assertThrows(ConstraintViolationException.class, ()->{
+			reviewService.createReview(requesterId, createReviewRequest);
+		});
+	}
+
+	@Test
+	void 리뷰설명_100자_이상에_따른_리뷰_생성_실패() {
+		// given
+		String title = "테스트 리뷰";
+		String description = """
+			aB3XzL7vYp0Kq1iFgT5uH2rW8cO4sD6nJ9mVxZlEoGyIuPqRtS3XbA2CvKjN0MfaB3XzL
+			7vYp0Kq1iFgT5uH2rW8cO4sD6nJ9mVxZlEoGyIuPqRtS3XbA2CvKjN0MfaB3XzL7vYp0K
+			1iFgT5uH2rW8cO4sD6nJ9mVxZlEoGyIuPqRtS3XbA2CvKjN0MfaB3XzL7vYp0Kq1iFgT5
+			uH2rW8cO4sD6nJ9mVxZlEoGyIuPqRtS3XbA2CvKjN0MfaB3XzL7vYp0Kq1iFgT5uH2rW8
+			cO4sD6nJ9mVxZlEoGyIuPqRtS3XbA2CvKjN0Mf
+			""";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		Long requesterId = 1L;
+
+		// when then
+		assertThrows(ConstraintViolationException.class, ()->{
+			reviewService.createReview(requesterId, createReviewRequest);
+		});
+	}
+
+	@Test
+	void 리뷰생성자_부재에_따른_리뷰_생성_실패() {
+		// given
+		String title = "테스트 리뷰";
+		String description = "이 리뷰는 테스트입니다.";
+		ReviewType type = ReviewType.PEER_REVIEW;
+		List<CreateQuestionRequest> createQuestionRequests = new ArrayList<>();
+		List<Long> responserIds = new ArrayList<>();
+
+		CreateReviewRequest createReviewRequest = new CreateReviewRequest(
+			title,
+			description,
+			type,
+			createQuestionRequests,
+			responserIds
+		);
+
+		Long requesterId = null;
+
+		// when then
+		assertThrows(DataIntegrityViolationException.class, ()->{
+			reviewService.createReview(requesterId, createReviewRequest);
+		});
+	}
+}

--- a/src/test/java/com/devcourse/ReviewRanger/user/service/TestPrincipalDetailsService.java
+++ b/src/test/java/com/devcourse/ReviewRanger/user/service/TestPrincipalDetailsService.java
@@ -1,0 +1,29 @@
+package com.devcourse.ReviewRanger.user.service;
+
+import static com.devcourse.ReviewRanger.user.service.UserFixture.*;
+
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+
+@Profile("test")
+public class TestPrincipalDetailsService implements UserDetailsService {
+
+	public static final String USER_EMAIL = "dev1234@devcource.com";
+
+	private User getUser() {
+		return SUYEON_FIXTURE.toEntity();
+	}
+
+	@Override
+	public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
+		if (email.equals(USER_EMAIL)) {
+			return new UserPrincipal(getUser());
+		}
+		return null;
+	}
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 리뷰 생성 테스트 코드를 추가했습니다.
- 테스트 환경에서 UserPrincipal 사용을 위해 의존성을 추가하고 testUesrDetailService를 추가했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- api 테스트는 성공할 때 true값을 주고, 실패는 예외 결과를 반환하기 때문에 성공만 작성헀고 어떤 입력을 받고 반환하는지 표현하기 위해 작성했습니다.
- service 테스트는  도메인 객체에서 유효성 검사를 하다보니 서비스 테스트에서 어떤 경우에 어떤 예외가 발생하는지 표현하기 위해 작성했습니다.
- 요청 dto에서 toEntity로 반환할 때 도메인의 유효성 검사가 일어나기 때문에 서비스 로직에서 테스트가 더 많아졌습니다. 검증 중복이 두번 일어나는게 비효율적이라 생각해서 우선 dto자체에서의 유효성 검사는 보류했습니다. 기능상으론 정상 동작합니다. 우선순위가 높은 것을 끝낸 후 논의하여 맞춰보도록 하겠습니다.
- 어떤 값에 어떤 오류가 발생한다는 것을 바로 전달하기 위해 테스트 메서드 마다 request값을 새로 만들었습니다. 지저분 하다면 다음 관련된 pr을 수행하며 userfixture 형식에 맞춰 작성해보겠습니다.