### PR TITLE
[REV-212] `user`도메인과 `auth`도메인 분리 작업

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/auth/api/AuthController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/api/AuthController.java
@@ -1,0 +1,93 @@
+package com.devcourse.ReviewRanger.auth.api;
+
+import javax.validation.Valid;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.devcourse.ReviewRanger.auth.application.AuthService;
+import com.devcourse.ReviewRanger.common.response.RangerResponse;
+import com.devcourse.ReviewRanger.auth.dto.JoinRequest;
+import com.devcourse.ReviewRanger.auth.dto.LoginRequest;
+import com.devcourse.ReviewRanger.auth.dto.LoginResponse;
+import com.devcourse.ReviewRanger.auth.dto.ValidateEmailRequest;
+import com.devcourse.ReviewRanger.auth.dto.ValidateNameRequest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@RestController
+@Tag(name = "auth", description = "사용자 인증 API")
+public class AuthController {
+
+	private final AuthService authService;
+
+	public AuthController(AuthService authService) {
+		this.authService = authService;
+	}
+
+	@Tag(name = "auth")
+	@Operation(summary = "회원가입", description = "사용자가 회원가입을 요청하는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "회원가입 성공"),
+		@ApiResponse(responseCode = "409", description = "이미 가입된 아이디를 입력한 경우"),
+		@ApiResponse(responseCode = "409", description = "이미 가입된 이메일을 입력한 경우")
+	})
+	@PostMapping("/sign-up")
+	public RangerResponse<Void> join(@RequestBody @Valid JoinRequest request) {
+		Boolean joinSuccess = authService.join(request);
+
+		return RangerResponse.ok(joinSuccess);
+	}
+
+	@Tag(name = "auth")
+	@Operation(summary = "로그인", description = "사용자가 로그인을 요청하는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "로그인 성공"),
+		@ApiResponse(responseCode = "422", description = "잘못된 로그인 정보를 입력한 경우"),
+	})
+	@PostMapping("/login")
+	public RangerResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
+		LoginResponse loginResponse = authService.login(request);
+
+		return RangerResponse.ok(loginResponse);
+	}
+
+	@Tag(name = "auth")
+	@Operation(summary = "[토큰] 로그아웃", description = "[토큰] 사용자가 로그아웃을 요청하는 API", responses = {
+		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+		@ApiResponse(responseCode = "401", description = "토큰을 넣지 않은 경우"),
+	})
+	@PostMapping("/members/logout")
+	public RangerResponse<Void> logout(
+		@RequestHeader("Authorization") String accessToken
+	) {
+		authService.logout(accessToken);
+		return RangerResponse.noData();
+	}
+
+	@Tag(name = "auth")
+	@Operation(summary = "이름 중복검사", description = "이름 중복 검사 API", responses = {
+		@ApiResponse(responseCode = "200", description = "이름이 중복되지 않음"),
+		@ApiResponse(responseCode = "409", description = "이미 가입된 이름을 입력한 경우")
+	})
+	@PostMapping("/members/check-name")
+	public RangerResponse<Void> checkname(@RequestBody @Valid ValidateNameRequest request) {
+		boolean notExistName = authService.isNotExistName(request.name());
+
+		return RangerResponse.ok(notExistName);
+	}
+
+	@Tag(name = "auth")
+	@Operation(summary = "이메일 중복검사", description = "이메일 중복 검사 API", responses = {
+		@ApiResponse(responseCode = "200", description = "이메일이 중복되지 않음"),
+		@ApiResponse(responseCode = "409", description = "이미 가입된 이메일을 입력한 경우")
+	})
+	@PostMapping("/members/check-email")
+	public RangerResponse<Void> checkEmail(@RequestBody @Valid ValidateEmailRequest request) {
+		boolean notExistEmail = authService.isNotExistEmail(request.email());
+
+		return RangerResponse.ok(notExistEmail);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/auth/application/AuthService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/application/AuthService.java
@@ -1,0 +1,86 @@
+package com.devcourse.ReviewRanger.auth.application;
+
+import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.devcourse.ReviewRanger.common.exception.RangerException;
+import com.devcourse.ReviewRanger.common.jwt.JwtTokenProvider;
+import com.devcourse.ReviewRanger.common.redis.RedisUtil;
+import com.devcourse.ReviewRanger.user.domain.User;
+import com.devcourse.ReviewRanger.auth.dto.JoinRequest;
+import com.devcourse.ReviewRanger.auth.dto.LoginRequest;
+import com.devcourse.ReviewRanger.auth.dto.LoginResponse;
+import com.devcourse.ReviewRanger.user.repository.UserRepository;
+
+@Service
+@Transactional(readOnly = true)
+public class AuthService {
+
+	private final UserRepository userRepository;
+	private final PasswordEncoder passwordEncoder;
+	private final AuthenticationManagerBuilder authenticationManagerBuilder;
+	private final JwtTokenProvider jwtTokenProvider;
+	private final RedisUtil redisUtil;
+
+	public AuthService(UserRepository userRepository, PasswordEncoder passwordEncoder,
+		AuthenticationManagerBuilder authenticationManagerBuilder, JwtTokenProvider jwtTokenProvider,
+		RedisUtil redisUtil) {
+		this.userRepository = userRepository;
+		this.passwordEncoder = passwordEncoder;
+		this.authenticationManagerBuilder = authenticationManagerBuilder;
+		this.jwtTokenProvider = jwtTokenProvider;
+		this.redisUtil = redisUtil;
+	}
+
+	@Transactional
+	public Boolean join(JoinRequest request) {
+		String encodedPassword = passwordEncoder.encode(request.password());
+		User newUser = request.toEntity(encodedPassword);
+
+		if (!isNotExistName(request.name())) {
+			throw new RangerException(EXIST_SAME_NAME);
+		}
+
+		if (!isNotExistEmail(request.email())) {
+			throw new RangerException(EXIST_SAME_EMAIL);
+		}
+
+		return (userRepository.save(newUser).getId()) > 0;
+	}
+
+	public LoginResponse login(LoginRequest request) {
+		// user 검증
+		UsernamePasswordAuthenticationToken authenticationToken
+			= new UsernamePasswordAuthenticationToken(request.email(), request.password());
+		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
+
+		// token 생성
+		String accessToken = jwtTokenProvider.createToken(authentication);
+
+		return new LoginResponse(accessToken, "Bearer");
+	}
+
+	public void logout(String accessToken) {
+		accessToken = getAccessToken(accessToken);
+		redisUtil.setBlackList(accessToken, "accessToken", 5);
+	}
+
+	private String getAccessToken(String accessToken) {
+		String[] tokenSplit = accessToken.split("\\s");
+		return tokenSplit[1];
+	}
+
+	public boolean isNotExistName(String name) {
+		return !userRepository.existsByName(name);
+	}
+
+	public boolean isNotExistEmail(String email) {
+		return !userRepository.existsByEmail(email);
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/auth/application/CustomUserDetailsService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/application/CustomUserDetailsService.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.application;
+package com.devcourse.ReviewRanger.auth.application;
 
 import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
@@ -8,7 +8,7 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Component;
 
 import com.devcourse.ReviewRanger.common.exception.RangerException;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
 @Component

--- a/src/main/java/com/devcourse/ReviewRanger/auth/domain/UserPrincipal.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/domain/UserPrincipal.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.domain;
+package com.devcourse.ReviewRanger.auth.domain;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -7,6 +7,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
 
+import com.devcourse.ReviewRanger.user.domain.User;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class UserPrincipal implements UserDetails {

--- a/src/main/java/com/devcourse/ReviewRanger/auth/dto/JoinRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/dto/JoinRequest.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.dto;
+package com.devcourse.ReviewRanger.auth.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 

--- a/src/main/java/com/devcourse/ReviewRanger/auth/dto/LoginRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/dto/LoginRequest.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.dto;
+package com.devcourse.ReviewRanger.auth.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 

--- a/src/main/java/com/devcourse/ReviewRanger/auth/dto/LoginResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/dto/LoginResponse.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.dto;
+package com.devcourse.ReviewRanger.auth.dto;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/src/main/java/com/devcourse/ReviewRanger/auth/dto/ValidateEmailRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/dto/ValidateEmailRequest.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.dto;
+package com.devcourse.ReviewRanger.auth.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 

--- a/src/main/java/com/devcourse/ReviewRanger/auth/dto/ValidateNameRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/auth/dto/ValidateNameRequest.java
@@ -1,4 +1,4 @@
-package com.devcourse.ReviewRanger.user.dto;
+package com.devcourse.ReviewRanger.auth.dto;
 
 import static com.devcourse.ReviewRanger.common.regex.UserRegex.*;
 

--- a/src/main/java/com/devcourse/ReviewRanger/common/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/jwt/JwtTokenProvider.java
@@ -22,7 +22,7 @@ import org.springframework.stereotype.Component;
 
 import com.devcourse.ReviewRanger.common.exception.RangerException;
 import com.devcourse.ReviewRanger.common.redis.RedisUtil;
-import com.devcourse.ReviewRanger.user.application.CustomUserDetailsService;
+import com.devcourse.ReviewRanger.auth.application.CustomUserDetailsService;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -67,7 +67,7 @@ public class JwtTokenProvider {
 		Claims claims = parseClaims(accessToken);
 
 		if (claims.get("auth") == null) {
-			throw new RangerException(NOT_AUTHORIZED_TOKEN);
+			throw new RangerException(NOT_AUTHORIZED_TOKEN); // TODO 핸들러 예외 처리 추가
 		}
 
 		Collection<? extends GrantedAuthority> authorities =

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
@@ -26,7 +26,7 @@ import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReviewRespons
 import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewAnswerResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewResultResponse;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/api/ParticipationController.java
@@ -21,7 +21,7 @@ import com.devcourse.ReviewRanger.participation.application.ParticipationService
 import com.devcourse.ReviewRanger.participation.dto.request.SubmitParticipationRequest;
 import com.devcourse.ReviewRanger.participation.dto.request.UpdateParticipationRequest;
 import com.devcourse.ReviewRanger.participation.dto.response.GetParticipationResponse;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -22,7 +22,7 @@ import com.devcourse.ReviewRanger.review.dto.request.CreateReviewRequest;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailFirstResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewDetailResponse;
 import com.devcourse.ReviewRanger.review.dto.response.GetReviewResponse;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.user.dto.GetUserResponse;
 
 import io.swagger.v3.oas.annotations.Operation;
@@ -63,11 +63,12 @@ public class ReviewController {
 	@GetMapping("/reviews")
 	public RangerResponse<Slice<GetReviewResponse>> getAllReviewsByRequesterOfCursorPaging(
 		@AuthenticationPrincipal UserPrincipal user,
-		@RequestParam(required = false ) Long cursorId,
-		@RequestParam(defaultValue = "12" ) Integer size
+		@RequestParam(required = false) Long cursorId,
+		@RequestParam(defaultValue = "12") Integer size
 	) {
 		Pageable pageable = PageRequest.of(0, size);
-		Slice<GetReviewResponse> responses = reviewService.getAllReviewsByRequesterOfCursorPaging(cursorId, user.getId(),pageable);
+		Slice<GetReviewResponse> responses = reviewService.getAllReviewsByRequesterOfCursorPaging(cursorId,
+			user.getId(), pageable);
 
 		return RangerResponse.ok(responses);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/user/api/UserController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/api/UserController.java
@@ -7,23 +7,16 @@ import javax.validation.Valid;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.common.response.RangerResponse;
 import com.devcourse.ReviewRanger.user.application.UserService;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.user.dto.GetUserResponse;
-import com.devcourse.ReviewRanger.user.dto.JoinRequest;
-import com.devcourse.ReviewRanger.user.dto.LoginRequest;
-import com.devcourse.ReviewRanger.user.dto.LoginResponse;
 import com.devcourse.ReviewRanger.user.dto.UpdateNameRequest;
 import com.devcourse.ReviewRanger.user.dto.UpdatePasswordRequest;
 import com.devcourse.ReviewRanger.user.dto.UserInfoResponse;
-import com.devcourse.ReviewRanger.user.dto.ValidateEmailRequest;
-import com.devcourse.ReviewRanger.user.dto.ValidateNameRequest;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -37,68 +30,6 @@ public class UserController {
 
 	public UserController(UserService userService) {
 		this.userService = userService;
-	}
-
-	@Tag(name = "user")
-	@Operation(summary = "회원가입", description = "사용자가 회원가입을 요청하는 API", responses = {
-		@ApiResponse(responseCode = "200", description = "회원가입 성공"),
-		@ApiResponse(responseCode = "409", description = "이미 가입된 아이디를 입력한 경우"),
-		@ApiResponse(responseCode = "409", description = "이미 가입된 이메일을 입력한 경우")
-	})
-	@PostMapping("/sign-up")
-	public RangerResponse<Void> join(@RequestBody @Valid JoinRequest request) {
-		Boolean joinSuccess = userService.join(request);
-
-		return RangerResponse.ok(joinSuccess);
-	}
-
-	@Tag(name = "user")
-	@Operation(summary = "로그인", description = "사용자가 로그인을 요청하는 API", responses = {
-		@ApiResponse(responseCode = "200", description = "로그인 성공"),
-		@ApiResponse(responseCode = "422", description = "잘못된 로그인 정보를 입력한 경우"),
-	})
-	@PostMapping("/login")
-	public RangerResponse<LoginResponse> login(@RequestBody @Valid LoginRequest request) {
-		LoginResponse loginResponse = userService.login(request);
-
-		return RangerResponse.ok(loginResponse);
-	}
-
-	@Tag(name = "user")
-	@Operation(summary = "[토큰] 로그아웃", description = "[토큰] 사용자가 로그아웃을 요청하는 API", responses = {
-		@ApiResponse(responseCode = "200", description = "로그아웃 성공"),
-		@ApiResponse(responseCode = "401", description = "토큰을 넣지 않은 경우"),
-	})
-	@PostMapping("/members/logout")
-	public RangerResponse<Void> logout(
-		@RequestHeader("Authorization") String accessToken
-	) {
-		userService.logout(accessToken);
-		return RangerResponse.noData();
-	}
-
-	@Tag(name = "user")
-	@Operation(summary = "이름 중복검사", description = "이름 중복 검사 API", responses = {
-		@ApiResponse(responseCode = "200", description = "이름이 중복되지 않음"),
-		@ApiResponse(responseCode = "409", description = "이미 가입된 이름을 입력한 경우")
-	})
-	@PostMapping("/members/check-name")
-	public RangerResponse<Void> checkname(@RequestBody @Valid ValidateNameRequest request) {
-		boolean notExistName = userService.isNotExistName(request.name());
-
-		return RangerResponse.ok(notExistName);
-	}
-
-	@Tag(name = "user")
-	@Operation(summary = "이메일 중복검사", description = "이메일 중복 검사 API", responses = {
-		@ApiResponse(responseCode = "200", description = "이메일이 중복되지 않음"),
-		@ApiResponse(responseCode = "409", description = "이미 가입된 이메일을 입력한 경우")
-	})
-	@PostMapping("/members/check-email")
-	public RangerResponse<Void> checkEmail(@RequestBody @Valid ValidateEmailRequest request) {
-		boolean notExistEmail = userService.isNotExistEmail(request.email());
-
-		return RangerResponse.ok(notExistEmail);
 	}
 
 	@Tag(name = "user")

--- a/src/main/java/com/devcourse/ReviewRanger/user/application/UserService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/application/UserService.java
@@ -4,22 +4,14 @@ import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
 import java.util.List;
 
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.common.exception.RangerException;
-import com.devcourse.ReviewRanger.common.jwt.JwtTokenProvider;
-import com.devcourse.ReviewRanger.common.redis.RedisUtil;
 import com.devcourse.ReviewRanger.user.domain.User;
-import com.devcourse.ReviewRanger.user.domain.UserPrincipal;
 import com.devcourse.ReviewRanger.user.dto.GetUserResponse;
-import com.devcourse.ReviewRanger.user.dto.JoinRequest;
-import com.devcourse.ReviewRanger.user.dto.LoginRequest;
-import com.devcourse.ReviewRanger.user.dto.LoginResponse;
 import com.devcourse.ReviewRanger.user.dto.UserInfoResponse;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
@@ -30,59 +22,15 @@ public class UserService {
 	private final UserRepository userRepository;
 	private final PasswordEncoder passwordEncoder;
 
-	private final AuthenticationManagerBuilder authenticationManagerBuilder;
-	private final JwtTokenProvider jwtTokenProvider;
-	private final RedisUtil redisUtil;
-
-	public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder,
-		AuthenticationManagerBuilder authenticationManagerBuilder, JwtTokenProvider jwtTokenProvider,
-		RedisUtil redisUtil) {
+	public UserService(UserRepository userRepository, PasswordEncoder passwordEncoder) {
 		this.userRepository = userRepository;
 		this.passwordEncoder = passwordEncoder;
-		this.authenticationManagerBuilder = authenticationManagerBuilder;
-		this.jwtTokenProvider = jwtTokenProvider;
-		this.redisUtil = redisUtil;
-	}
-
-	@Transactional
-	public Boolean join(JoinRequest request) {
-		String encodedPassword = passwordEncoder.encode(request.password());
-		User newUser = request.toEntity(encodedPassword);
-
-		if (!isNotExistName(request.name())) {
-			throw new RangerException(EXIST_SAME_NAME);
-		}
-
-		if (!isNotExistEmail(request.email())) {
-			throw new RangerException(EXIST_SAME_EMAIL);
-		}
-
-		return (userRepository.save(newUser).getId()) > 0;
-	}
-
-	public LoginResponse login(LoginRequest request) {
-		// user 검증
-		UsernamePasswordAuthenticationToken authenticationToken
-			= new UsernamePasswordAuthenticationToken(request.email(), request.password());
-		Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
-
-		// token 생성
-		String accessToken = jwtTokenProvider.createToken(authentication);
-
-		return new LoginResponse(accessToken, "Bearer");
-	}
-
-	public boolean isNotExistName(String name) {
-		return !userRepository.existsByName(name);
-	}
-
-	public boolean isNotExistEmail(String email) {
-		return !userRepository.existsByEmail(email);
 	}
 
 	@Transactional
 	public void updateName(Long id, String editName) {
-		if (!isNotExistName(editName)) {
+		boolean isExistName = userRepository.existsByName(editName);
+		if (isExistName) {
 			throw new RangerException(EXIST_SAME_NAME);
 		}
 
@@ -95,16 +43,6 @@ public class UserService {
 		User user = getUserOrThrow(id);
 		editEncodedPassword = passwordEncoder.encode(editEncodedPassword);
 		user.updatePassword(editEncodedPassword);
-	}
-
-	public void logout(String accessToken) {
-		accessToken = getAccessToken(accessToken);
-		redisUtil.setBlackList(accessToken, "accessToken", 5);
-	}
-
-	private String getAccessToken(String accessToken) {
-		String[] tokenSplit = accessToken.split("\\s");
-		return tokenSplit[1];
 	}
 
 	public User getUserOrThrow(Long id) {

--- a/src/main/java/com/devcourse/ReviewRanger/user/dto/UpdatePasswordRequest.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/dto/UpdatePasswordRequest.java
@@ -7,6 +7,7 @@ import javax.validation.constraints.Pattern;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 
+@Schema(description = "사용자 비밀번호 변경 요청 DTO")
 public record UpdatePasswordRequest(
 	@Schema(description = "변경 할 비밀번호")
 	@NotBlank(message = "비밀번호는 빈값 일 수 없습니다.")

--- a/src/test/java/com/devcourse/ReviewRanger/user/UserFixture.java
+++ b/src/test/java/com/devcourse/ReviewRanger/user/UserFixture.java
@@ -1,7 +1,7 @@
-package com.devcourse.ReviewRanger.user.service;
+package com.devcourse.ReviewRanger.user;
 
 import com.devcourse.ReviewRanger.user.domain.User;
-import com.devcourse.ReviewRanger.user.dto.JoinRequest;
+import com.devcourse.ReviewRanger.auth.dto.JoinRequest;
 
 public enum UserFixture {
 

--- a/src/test/java/com/devcourse/ReviewRanger/user/service/UserServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/user/service/UserServiceTest.java
@@ -1,15 +1,10 @@
 package com.devcourse.ReviewRanger.user.service;
 
-import static com.devcourse.ReviewRanger.user.service.UserFixture.*;
-import static org.junit.jupiter.api.Assertions.*;
-
-import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.devcourse.ReviewRanger.user.application.UserService;
-import com.devcourse.ReviewRanger.user.dto.JoinRequest;
 
 @Transactional
 @SpringBootTest


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- user도메인에 섞여있던 auth도메인 작업을 분리하였습니다.
- swagger는 user와 auth tag로 분리됩니다.
<img width="1275" alt="스크린샷 2023-11-20 오전 2 55 26" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/b9cfb37c-8a40-4bd9-a36c-34b72a6736cc">


### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- api 경로와 로직은 변경된 것이 없어 그대로 잘 동작합니다!
