### PR TITLE
[REV-283] 모든 수신자 결과 수신 검증 API 수정

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/config/WebConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/WebConfig.java
@@ -12,7 +12,7 @@ public class WebConfig implements WebMvcConfigurer {
 			.allowedOriginPatterns(
 				"http://localhost:3001",
 				"http://localhost:5173/",
-				"http://devserver-review-ranger.s3-website.ap-northeast-2.amazonaws.com/"
+				"http://team12-bucket.s3-website.ap-northeast-2.amazonaws.com/"
 			)
 			.allowedMethods("GET", "POST", "PUT", "DELETE", "PATCH")
 			.allowedHeaders("Authorization", "Content-Type")

--- a/src/main/java/com/devcourse/ReviewRanger/common/response/RangerResponse.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/response/RangerResponse.java
@@ -26,6 +26,10 @@ public class RangerResponse<T> {
 		return new RangerResponse<>(true, data);
 	}
 
+	public static <T> RangerResponse<T> ok(Boolean success, T data) {
+		return new RangerResponse<>(success, data);
+	}
+
 	public static RangerResponse<Void> noData() {
 		return new RangerResponse<>(true, null);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
@@ -3,6 +3,7 @@ package com.devcourse.ReviewRanger.finalReviewResult.api;
 import static org.springframework.http.HttpStatus.*;
 
 import java.util.List;
+import java.util.Set;
 
 import javax.validation.Valid;
 
@@ -21,6 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.ReviewRanger.common.response.RangerResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.application.FinalReviewResultService;
+import com.devcourse.ReviewRanger.finalReviewResult.dto.CheckFinalResultStatus;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReviewRequest;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReviewResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListResponse;
@@ -102,12 +104,12 @@ public class FinalReviewResultController {
 	})
 	@GetMapping("/{reviewId}/status")
 	@ResponseStatus(OK)
-	public RangerResponse<Void> checkFinalResultStatus(
+	public RangerResponse<Set<Long>> checkFinalResultStatus(
 		@PathVariable Long reviewId
 	) {
-		Boolean checkStatus = finalReviewResultService.checkFinalResultStatus(reviewId);
+		CheckFinalResultStatus checkStatus = finalReviewResultService.checkFinalResultStatus(reviewId);
 
-		return RangerResponse.ok(checkStatus);
+		return RangerResponse.ok(checkStatus.checkStatus(), checkStatus.userId());
 	}
 
 	@Tag(name = "final-result")

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/CheckFinalResultStatus.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/CheckFinalResultStatus.java
@@ -1,0 +1,15 @@
+package com.devcourse.ReviewRanger.finalReviewResult.dto;
+
+import java.util.Set;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "모든 수신자가 결과를 받았는지 검증 결과 DTO")
+public record CheckFinalResultStatus(
+	@Schema(description = "검증 상태")
+	Boolean checkStatus,
+
+	@Schema(description = "결과를 가진 user id 목록")
+	Set<Long> userId
+) {
+}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 모든 수신자가 리뷰 결과를 가지는지 검증 기능 추가 + 리뷰 결과를 갖는 userId 목록을 넘겨주는 기능 추가
https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/pull/62
<img width="494" alt="스크린샷 2023-11-20 오후 6 39 23" src="https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/641f77f4-e798-462a-862b-cb07d4ff909c">


### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- `CheckFinalResultStatus`을 응답으로 받아 무조건 true값이 아닌 boolean 값을 넘겨줄 수 있도록 구현했습니다. 이를 위해 RangerResponse에 함수를 추가했습니다.


