### PR TITLE
[REV-285] 최종 리뷰 전송 시 리뷰 종료 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -41,6 +41,7 @@ import com.devcourse.ReviewRanger.finalReviewResult.repository.SubjectTypeReposi
 import com.devcourse.ReviewRanger.participation.domain.Participation;
 import com.devcourse.ReviewRanger.participation.repository.ParticipationRepository;
 import com.devcourse.ReviewRanger.question.repository.QuestionRepository;
+import com.devcourse.ReviewRanger.review.domain.Review;
 import com.devcourse.ReviewRanger.review.repository.ReviewRepository;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
@@ -176,7 +177,8 @@ public class FinalReviewResultService {
 
 	@Transactional
 	public void sendFinalResultToUsers(Long reviewId) {
-		validateReviewId(reviewId);
+		Review review = getReviewOrThrow(reviewId);
+		review.toClose();
 
 		List<Participation> participations = participationRepository.findAllByReviewId(reviewId);
 
@@ -187,6 +189,7 @@ public class FinalReviewResultService {
 		Set<Long> userIds = new HashSet<>();
 
 		for (Participation participation : participations) {
+			participation.closeReview();
 			Long participationId = participation.getId();
 			List<ReplyTarget> replyTargets = replyTargetRepository.findAllByParticipationId(participationId);
 
@@ -297,6 +300,11 @@ public class FinalReviewResultService {
 	private FinalReviewResult getFinalReviewResultOrThrow(Long finalResultId) {
 		return finalReviewResultRepository.findById(finalResultId)
 			.orElseThrow(() -> new RangerException(NOT_FOUND_FINAL_REVIEW_RESULT));
+	}
+
+	private Review getReviewOrThrow(Long reviewId) {
+		return reviewRepository.findById(reviewId)
+			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW));
 	}
 
 	private void validateQuestionId(Long questionId) {

--- a/src/main/java/com/devcourse/ReviewRanger/participation/domain/Participation.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/domain/Participation.java
@@ -1,5 +1,6 @@
 package com.devcourse.ReviewRanger.participation.domain;
 
+import static com.devcourse.ReviewRanger.participation.domain.ReviewStatus.*;
 import static com.fasterxml.jackson.annotation.JsonFormat.Shape.*;
 
 import java.time.LocalDateTime;
@@ -62,5 +63,9 @@ public class Participation extends BaseEntity {
 	public void answeredReview() {
 		this.submitAt = LocalDateTime.now();
 		this.isAnswered = true;
+	}
+
+	public void closeReview() {
+		this.reviewStatus = END;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/review/domain/Review.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/domain/Review.java
@@ -70,5 +70,6 @@ public class Review extends BaseEntity {
 
 	public void toClose() {
 		this.status = END;
+		this.closedAt = LocalDateTime.now();
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/review/domain/Review.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/domain/Review.java
@@ -67,4 +67,8 @@ public class Review extends BaseEntity {
 	public void changeStatus(ReviewStatus status) {
 		this.status = status;
 	}
+
+	public void toClose() {
+		this.status = END;
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/slack/SlackController.java
@@ -16,7 +16,7 @@ public class SlackController {
 	}
 
 	@PostMapping("/alert")
-	public void alertMessage(@RequestParam("title") String title) {
+	public void alertMessage(@RequestParam("text") String title) {
 		slackService.alertSlackMessage(title);
 	}
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 해당 전송 버튼을 눌렀을 때 최종 리뷰가 전송 상태로 변함과 동시에 리뷰, 참여 Entity도 함께 종료 상태로 변하도록 수정하였습니다.
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/5cc47550-143a-4301-90fc-dad5a603c3f9)
- 이전 PR -> (#64)

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- Entity에서 해당 역할을 수행하도록 하였고 비즈니스 로직에서는 Entity의 메소드만 호출하는 방식으로 구현하였습니다. 도메인!!!

