### PR TITLE
[REV-286] jwt 토큰 예외 핸들러 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/config/SecurityConfig.java
@@ -15,19 +15,22 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import com.devcourse.ReviewRanger.common.jwt.ExceptionHandlerFilter;
 import com.devcourse.ReviewRanger.common.jwt.JwtFilter;
-import com.devcourse.ReviewRanger.common.jwt.JwtTokenProvider;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
 
-	private final JwtTokenProvider jwtTokenProvider;
+	private final ExceptionHandlerFilter exceptionHandlerFilter;
+	private final JwtFilter jwtFilter;
+
 	private final String[] permitUrls = {"/login", "/sign-up", "/members/check-id", "/members/check-email",
 		"/swagger-ui", "/swagger-ui/**"};
 
-	public SecurityConfig(JwtTokenProvider jwtTokenProvider) {
-		this.jwtTokenProvider = jwtTokenProvider;
+	public SecurityConfig(ExceptionHandlerFilter exceptionHandlerFilter, JwtFilter jwtFilter) {
+		this.exceptionHandlerFilter = exceptionHandlerFilter;
+		this.jwtFilter = jwtFilter;
 	}
 
 	@Bean
@@ -60,7 +63,9 @@ public class SecurityConfig {
 			.authorizeRequests()
 			.antMatchers(permitUrls).permitAll()
 			.and()
-			.addFilterBefore(new JwtFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+			.addFilterBefore(jwtFilter, UsernamePasswordAuthenticationFilter.class)
+			.addFilterBefore(exceptionHandlerFilter, JwtFilter.class);
+
 		return http.build();
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/common/jwt/ExceptionHandlerFilter.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/jwt/ExceptionHandlerFilter.java
@@ -1,0 +1,44 @@
+package com.devcourse.ReviewRanger.common.jwt;
+
+import java.io.IOException;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.devcourse.ReviewRanger.common.exception.GlobalExceptionHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import io.jsonwebtoken.JwtException;
+
+@Component
+public class ExceptionHandlerFilter extends OncePerRequestFilter {
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		try {
+			filterChain.doFilter(request, response);
+		} catch (JwtException ex) {
+			setErrorResponse(HttpStatus.UNAUTHORIZED, request, response, ex);
+		}
+	}
+
+	public void setErrorResponse(HttpStatus status, HttpServletRequest request,
+		HttpServletResponse response, Throwable ex) throws IOException {
+		ObjectMapper objectMapper = new ObjectMapper();
+
+		response.setStatus(status.value());
+		response.setContentType("application/json; charset=UTF-8");
+
+		GlobalExceptionHandler.ErrorResponse errorResponse = new GlobalExceptionHandler.ErrorResponse(
+			HttpStatus.UNAUTHORIZED, HttpStatus.UNAUTHORIZED.name(), ex.getMessage());
+
+		response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+	}
+}

--- a/src/main/java/com/devcourse/ReviewRanger/common/jwt/JwtFilter.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/jwt/JwtFilter.java
@@ -10,11 +10,10 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
-import lombok.extern.slf4j.Slf4j;
-
-@Slf4j
+@Component
 public class JwtFilter extends OncePerRequestFilter {
 
 	private static final String BEARER_PREFIX = "Bearer ";


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- jwt 토큰 유효성 검사에 필요한 jwt 예외 핸들러를 추가적으로 구현하였습니다.
- 유효하지 않은 jwt 응답이 200에서 401으로 변경되었습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- `IllegalArgumentException` 부분 예외 처리는 제외하였는데 postman에서 로그인할 때 토큰을 사용하지 않는데도 토큰 유효성 검사를 하는 문제가 있다고 해서 임시로 처리해 두었습니다! 추후에 주석풀고 테스트 후 배포하면 될 것 같습니다.
- 403은 데이터가 있고 넌 권한이 없음을 암시적으로 전달하기 때문에 보안상 401 응답 코드를 사용했습니다.

