### PR TITLE
[REV-288] 작성자별, 수신자별 응답 조회시 모든 리뷰의 작성자, 수신자를 가져오는 버그 수정

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/api/ReplyTargetRestController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/api/ReplyTargetRestController.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.devcourse.ReviewRanger.ReplyTarget.application.ReplyTargetService;
@@ -17,7 +16,6 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 
 @Tag(name = "reply-target", description = "리뷰 타겟 API")
 @RestController
-@RequestMapping("/reply-targets")
 public class ReplyTargetRestController {
 
 	private final ReplyTargetService replyTargetService;
@@ -32,10 +30,11 @@ public class ReplyTargetRestController {
 		@ApiResponse(responseCode = "404", description = "수신자가 존재하지 않는 경우"),
 
 	})
-	@GetMapping("/{id}/responser")
-	public RangerResponse<List<ReplyTargetResponse>> getRepliesByResponser(@PathVariable Long id) {
+	@GetMapping("/reviews/{reviewId}/responser/{responserId}")
+	public RangerResponse<List<ReplyTargetResponse>> getRepliesByResponser(@PathVariable Long reviewId,
+		@PathVariable Long responserId) {
 		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByResponser(
-			id);
+			reviewId, responserId);
 
 		return RangerResponse.ok(responses);
 	}
@@ -46,9 +45,10 @@ public class ReplyTargetRestController {
 		@ApiResponse(responseCode = "404", description = "수신자가 존재하지 않는 경우"),
 
 	})
-	@GetMapping("/{id}/receiver")
-	public RangerResponse<List<ReplyTargetResponse>> getRepliesByReceiver(@PathVariable Long id) {
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(id);
+	@GetMapping("/reviews/{reviewId}/receiver/{receiverId}")
+	public RangerResponse<List<ReplyTargetResponse>> getRepliesByReceiver(@PathVariable Long reviewId,
+		@PathVariable Long receiverId) {
+		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(reviewId, receiverId);
 
 		return RangerResponse.ok(responses);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
@@ -40,17 +40,18 @@ public class ReplyTargetService {
 	}
 
 	@Transactional
-	public void createReviewTarget(Long participationId,
+	public void createReviewTarget(Long participationId, Long reviewId,
 		List<CreateReplyTargetRequest> createReplyTargetRequests) {
 		for (CreateReplyTargetRequest createReplyTargetRequest : createReplyTargetRequests) {
 			User receiver = userRepository.findById(createReplyTargetRequest.receiverId())
 				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
 
-			User responer = userRepository.findById(createReplyTargetRequest.responserId())
+			User responser = userRepository.findById(createReplyTargetRequest.responserId())
 				.orElseThrow(() -> new RangerException(NOT_FOUND_USER));
 
-			ReplyTarget replyTarget = createReplyTargetRequest.toEntity(receiver, responer);
+			ReplyTarget replyTarget = createReplyTargetRequest.toEntity(receiver, responser);
 			replyTarget.setParticipationId(participationId);
+			replyTarget.setReviewId(reviewId);
 
 			ReplyTarget savedReplyTarget = replyTargetRepository.save(replyTarget);
 
@@ -65,15 +66,15 @@ public class ReplyTargetService {
 		}
 	}
 
-	public List<ReplyTargetResponse> getAllRepliesByResponser(Long responserId) {
-		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByResponserId(responserId);
+	public List<ReplyTargetResponse> getAllRepliesByResponser(Long reviewId, Long responserId) {
+		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReviewIdAndResponserId(reviewId, responserId);
 		List<ReplyTargetResponse> responses = getAllRepliesByReviewedTargets(replyTargets);
 
 		return responses;
 	}
 
-	public List<ReplyTargetResponse> getAllRepliesByReceiver(Long receiverId) {
-		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReceiverId(receiverId);
+	public List<ReplyTargetResponse> getAllRepliesByReceiver(Long reviewId, Long receiverId) {
+		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReviewIdAndReceiverId(reviewId, receiverId);
 		List<ReplyTargetResponse> responses = getAllRepliesByReviewedTargets(replyTargets);
 
 		return responses;

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/domain/ReplyTarget.java
@@ -36,6 +36,9 @@ public class ReplyTarget extends BaseEntity {
 	@Column(name = "participation_id", nullable = false)
 	private Long participationId;
 
+	@Column(name = "review_id", nullable = false)
+	private Long reviewId;
+
 	@OneToMany(mappedBy = "replyTarget", orphanRemoval = true)
 	private List<Reply> replies = new ArrayList<>();
 
@@ -54,5 +57,9 @@ public class ReplyTarget extends BaseEntity {
 
 	public void setParticipationId(Long participationId) {
 		this.participationId = participationId;
+	}
+
+	public void setReviewId(Long reviewId) {
+		this.reviewId = reviewId;
 	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/repository/ReplyTargetRepository.java
@@ -9,7 +9,7 @@ import com.devcourse.ReviewRanger.ReplyTarget.domain.ReplyTarget;
 public interface ReplyTargetRepository extends JpaRepository<ReplyTarget, Long>, ReplyTargetCustomRepository {
 	List<ReplyTarget> findAllByParticipationId(Long participationId);
 
-	List<ReplyTarget> findAllByReceiverId(Long receiverId);
+	List<ReplyTarget> findAllByReviewIdAndReceiverId(Long reviewId, Long receiverId);
 
-	List<ReplyTarget> findAllByResponserId(Long responerId);
+	List<ReplyTarget> findAllByReviewIdAndResponserId(Long reviewId, Long responerId);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -152,7 +152,8 @@ public class ParticipationService {
 	public void submitReplies(SubmitParticipationRequest request) {
 		Participation participation = getByIdOrThrow(request.participationId());
 
-		replyTargetService.createReviewTarget(participation.getId(), request.createReplyTargetRequests());
+		replyTargetService.createReviewTarget(participation.getId(), participation.getReviewId(),
+			request.createReplyTargetRequests());
 
 		participation.answeredReview();
 	}

--- a/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/api/ReplyTargetRestControllerTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/api/ReplyTargetRestControllerTest.java
@@ -98,9 +98,9 @@ class ReplyTargetRestControllerTest {
 	@Test
 	void 작성자_답변_조회_성공() throws Exception {
 
-		given(replyTargetService.getAllRepliesByResponser(1L)).willReturn(List.of(response));
+		given(replyTargetService.getAllRepliesByResponser(1L, 1L)).willReturn(List.of(response));
 
-		mockMvc.perform(get("/reply-targets/{id}/responser", 1L)
+		mockMvc.perform(get("/reviews/{reviewId}/responser/{responserId}", 1L, 1L)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(print());
@@ -109,9 +109,9 @@ class ReplyTargetRestControllerTest {
 	@Test
 	void 수신자_답변_조회_성공() throws Exception {
 
-		given(replyTargetService.getAllRepliesByReceiver(2L)).willReturn(List.of(response));
+		given(replyTargetService.getAllRepliesByReceiver(1L, 2L)).willReturn(List.of(response));
 
-		mockMvc.perform(get("/reply-targets/{id}/receiver", 2L)
+		mockMvc.perform(get("/reviews/{reviewId}/receiver/{receiverId}", 1L, 2L)
 				.contentType(MediaType.APPLICATION_JSON))
 			.andExpect(status().isOk())
 			.andDo(print());

--- a/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetServiceTest.java
@@ -54,16 +54,16 @@ class ReplyTargetServiceTest {
 
 		List<ReplyTarget> replyTargetList = List.of(replyTarget);
 
-		given(replyTargetRepository.findAllByResponserId(1L)).willReturn(replyTargetList);
+		given(replyTargetRepository.findAllByReviewIdAndResponserId(1L, 1L)).willReturn(replyTargetList);
 
 		//when
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByResponser(1L);
+		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByResponser(1L, 1L);
 
 		//then
-		assertThat(responses.get(0).responser().name()).isEqualTo("수연");
-		assertThat(responses.get(0).receiver().name()).isEqualTo("범철");
-		assertThat(responses.get(0).replies().get(0).answerText()).isEqualTo("수연 -> 범철 주관식 답변");
-		verify(replyTargetRepository, times(1)).findAllByResponserId(any(Long.class));
+		assertThat(responses.get(0).responser().name()).isEqualTo("장수연");
+		assertThat(responses.get(0).receiver().name()).isEqualTo("신범철");
+		assertThat(responses.get(0).replies().get(0).answerText()).isEqualTo("주관식 답변");
+		verify(replyTargetRepository, times(1)).findAllByReviewIdAndResponserId(any(Long.class), any(Long.class));
 	}
 
 	@Test
@@ -80,18 +80,18 @@ class ReplyTargetServiceTest {
 
 		List<ReplyTarget> replyTargetList = List.of(replyTarget);
 
-		given(replyTargetRepository.findAllByReceiverId(2L)).willReturn(replyTargetList);
+		given(replyTargetRepository.findAllByReviewIdAndReceiverId(1L, 2L)).willReturn(replyTargetList);
 		given(questionOptionRepository.findById(1L)).willReturn(Optional.of(questionOption));
 
 		//when
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(2L);
+		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(1L, 2L);
 
 		//then
-		assertThat(responses.get(0).responser().name()).isEqualTo("수연");
-		assertThat(responses.get(0).receiver().name()).isEqualTo("범철");
-		assertThat(responses.get(0).replies().get(0).answerText()).isEqualTo("수연 -> 범철 주관식 답변");
+		assertThat(responses.get(0).responser().name()).isEqualTo("장수연");
+		assertThat(responses.get(0).receiver().name()).isEqualTo("신범철");
+		assertThat(responses.get(0).replies().get(0).answerText()).isEqualTo("주관식 답변");
 		assertThat(responses.get(0).replies().get(1).questionOption().optionName()).isEqualTo("파이리");
 
-		verify(replyTargetRepository, times(1)).findAllByReceiverId(any(Long.class));
+		verify(replyTargetRepository, times(1)).findAllByReviewIdAndReceiverId(any(Long.class), any(Long.class));
 	}
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- ReviewId를 모르고 작성자와 수신자의 Id 값으로 조회하다 보니 모든 리뷰의 작성자 또는 수신자의 응답을 가져왔습니다.
- 그래서 ReviewId를 통해서 특정 리뷰의 작성자 또는 수신자의 응답으로 가져오도록 수정하였습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 단일 응답 조회의 핵심 로직을 수정하였고, 컨트롤러 및 다른 변경점들은 다음 PR에서 정리해서 올리겠습니다.

