### PR TITLE
[REV-224] 최종 리뷰 결과 상세 조회 단위테스트 추가

### DIFF
--- a/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/FinalReviewResultFixture.java
+++ b/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/FinalReviewResultFixture.java
@@ -55,4 +55,8 @@ public enum FinalReviewResultFixture {
 	public FinalReviewResult toEntity() {
 		return new FinalReviewResult(userId, userName, reviewId, title, description, status, questions);
 	}
+
+	public FinalReviewResult toEntity(List<FinalQuestion> questions) {
+		return new FinalReviewResult(userId, userName, reviewId, title, description, status, questions);
+	}
 }

--- a/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
@@ -173,8 +173,6 @@ class FinalReviewResultServiceTest {
 	void 최종_리뷰_전송_성공() {
 		// given
 		Long reviewId = 1L;
-		List<Long> participationIds = List.of(1L, 2L, 3L);
-		List<Long> userIds = List.of(1L, 2L, 3L);
 
 		Review fakeReview = BASIC_REVIEW.toEntity();
 		User fakeUser = SUYEON_FIXTURE.toEntity();


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 최종 리뷰 결과 상세조회 비즈니스 로직인 `getFinalReviewResultInfo`, `getFinalReviewAnswerList`에 대한 단위 테스트 코드를 mockito로 작성했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 최종 리뷰 도메인 정보 조회와 최종 리뷰에 달린 질문과 답변 리스트 조회에 대한 api가 따로여서 테스트를 따로 진행했습니다!

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 최종_리뷰_결과_상세조회_성공
- 최종_리뷰_결과_상세조회_실패
- 최종_리뷰_결과_답변_상세조회_성공
