### PR TITLE
[REV-183] 유저 도메인 로그아웃 단위 테스트 추가

### DIFF
--- a/src/test/java/com/devcourse/ReviewRanger/auth/application/AuthServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/auth/application/AuthServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 
 import com.devcourse.ReviewRanger.auth.dto.JoinRequest;
 import com.devcourse.ReviewRanger.common.exception.RangerException;
+import com.devcourse.ReviewRanger.common.redis.RedisUtil;
 import com.devcourse.ReviewRanger.user.domain.User;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
 
@@ -26,6 +27,9 @@ public class AuthServiceTest {
 
 	@Mock
 	private PasswordEncoder passwordEncoder;
+
+	@Mock
+	private RedisUtil redisUtil;
 
 	@Test
 	void 회원가입_성공_테스트() {
@@ -73,5 +77,18 @@ public class AuthServiceTest {
 		assertThrows(RangerException.class,
 			() -> authService.join(joinRequest)
 		);
+	}
+
+	@Test
+	void 로그아웃_성공_테스트() {
+		// given
+		String mockToken = "Bearer mockToken";
+		doNothing().when(redisUtil).setBlackList(anyString(), anyString(), anyInt());
+
+		// when
+		authService.logout(mockToken);
+
+		// then
+		verify(redisUtil, times(1)).setBlackList(anyString(), anyString(), anyInt());
 	}
 }


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 유저 도메인 인증 부문의 로그인 비즈니스 로직 `logout`에 대한 단위 테스트 코드를 mockito로 작성했습니다.

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 로그아웃_성공_테스트