### PR TITLE
[REV-290] 프로필 이미지 유효성 검증 및 고유한 이름 값 설정

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -12,6 +12,8 @@ public enum ErrorCode {
 	//400 error
 	MISSING_REQUIRED_QUESTION_REPLY(BAD_REQUEST, "필수 질문의 답변이 존재하지 않습니다."),
 	MISSING_IMAGE_CONVERT(BAD_REQUEST, "MultipartFile -> File 전환에 실패했습니다."),
+	EMPTY_IMAGE(BAD_REQUEST, "이미지가 없습니다."),
+	INVALID_IMAGE_EXTENSION(BAD_REQUEST, "이미지 확장자가 올바르지 않습니다."),
 
 	// 401 error
 	NOT_CORRECT_JWT(UNAUTHORIZED, "잘못된 JWT 토큰입니다."),

--- a/src/main/java/com/devcourse/ReviewRanger/common/image/infrastructure/S3manager.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/image/infrastructure/S3manager.java
@@ -63,7 +63,7 @@ public class S3manager implements ImageManager {
 		boolean isExtension = imageExtensions.contains(extension.toLowerCase());
 
 		if (!isExtension) {
-			log.warn("이미지 확장가 검증 오류 : {}", filename);
+			log.warn("이미지 확장자 검증 오류 : {}", filename);
 			throw new RangerException(INVALID_IMAGE_EXTENSION);
 		}
 

--- a/src/main/java/com/devcourse/ReviewRanger/user/application/UserService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/user/application/UserService.java
@@ -3,6 +3,7 @@ package com.devcourse.ReviewRanger.user.application;
 import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
 import java.util.List;
+import java.util.UUID;
 
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -46,7 +47,7 @@ public class UserService {
 	@Transactional
 	public void updateImage(Long id, MultipartFile multipartFile) {
 		User user = getUserOrThrow(id);
-		String fileName = user.getId() + multipartFile.getOriginalFilename();
+		String fileName = UUID.randomUUID() + multipartFile.getOriginalFilename();
 
 		s3Manager.delete(fileName, DIRECTORY);
 		String uploadImageUrl = s3Manager.upload(multipartFile, DIRECTORY, fileName);


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 프로필 이미지의 확장자를 `jpg`, `jpeg`, `png`만 가능하도록 설정하였습니다.
- 프로필 이미지 이름의 중복을 피하기 위해 랜덤 값으로 저장해 두었습니다.

### DB 
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/84673536/7be18721-17c8-45d3-a665-34f69d8ad916)

### S3
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/84673536/b8592570-6131-4636-be0f-764262055226)
