### PR TITLE
[REV-319] 최종 리뷰 결과 생성 시 중복 생성 방지 로직 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResult.java
@@ -86,4 +86,12 @@ public class FinalReviewResult extends BaseEntity {
 	public void addQuestions(FinalQuestion question) {
 		this.questions.add(question);
 	}
+
+	public List<Long> questionIds() {
+		List<Long> questionIds = new ArrayList<>();
+		for (FinalQuestion finalQuestion : questions) {
+			questionIds.add(finalQuestion.getQuestionId());
+		}
+		return questionIds;
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswer.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswer.java
@@ -16,13 +16,17 @@ public abstract class FinalReviewResultAnswer {
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
 
+	@Column(name = "user_id")
+	private Long userId;
+
 	@Column(name = "question_id")
 	private Long questionId;
 
 	protected FinalReviewResultAnswer() {
 	}
 
-	protected FinalReviewResultAnswer(Long questionId) {
+	protected FinalReviewResultAnswer(Long userId, Long questionId) {
+		this.userId = userId;
 		this.questionId = questionId;
 	}
 

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerDropdown.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerDropdown.java
@@ -16,8 +16,8 @@ public class FinalReviewResultAnswerDropdown extends FinalReviewResultAnswer {
 		super();
 	}
 
-	public FinalReviewResultAnswerDropdown(Long questionId) {
-		super(questionId);
+	public FinalReviewResultAnswerDropdown(Long userId, Long questionId) {
+		super(userId, questionId);
 	}
 
 	@Override

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerHexStat.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerHexStat.java
@@ -23,8 +23,8 @@ public class FinalReviewResultAnswerHexStat extends FinalReviewResultAnswer {
 		super();
 	}
 
-	public FinalReviewResultAnswerHexStat(Long questionId) {
-		super(questionId);
+	public FinalReviewResultAnswerHexStat(Long userId, Long questionId) {
+		super(userId, questionId);
 	}
 
 	@Override

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerObjects.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerObjects.java
@@ -16,8 +16,8 @@ public class FinalReviewResultAnswerObjects extends FinalReviewResultAnswer {
 		super();
 	}
 
-	public FinalReviewResultAnswerObjects(Long questionId) {
-		super(questionId);
+	public FinalReviewResultAnswerObjects(Long userId, Long questionId) {
+		super(userId, questionId);
 	}
 
 	@Override

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerRating.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerRating.java
@@ -18,8 +18,8 @@ public class FinalReviewResultAnswerRating extends FinalReviewResultAnswer {
 		super();
 	}
 
-	public FinalReviewResultAnswerRating(Long questionId) {
-		super(questionId);
+	public FinalReviewResultAnswerRating(Long userId, Long questionId) {
+		super(userId, questionId);
 	}
 
 	@Override

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerSubject.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerSubject.java
@@ -16,8 +16,8 @@ public class FinalReviewResultAnswerSubject extends FinalReviewResultAnswer {
 		super();
 	}
 
-	public FinalReviewResultAnswerSubject(Long questionId) {
-		super(questionId);
+	public FinalReviewResultAnswerSubject(Long userId, Long questionId) {
+		super(userId, questionId);
 	}
 
 	@Override

--- a/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
@@ -241,11 +241,11 @@ class FinalReviewResultServiceTest {
 		);
 		FinalReviewResult fakeFinalReviewResult = FinalReviewResultFixture.BASIC_FIXTURE.toEntity(fakeFinalQuestions);
 
-		FinalReviewResultAnswerSubject subjectAnswer = new FinalReviewResultAnswerSubject(1L);
-		FinalReviewResultAnswerObjects objectAnswer = new FinalReviewResultAnswerObjects(2L);
-		FinalReviewResultAnswerRating ratingAnswer = new FinalReviewResultAnswerRating(3L);
-		FinalReviewResultAnswerDropdown dropdownAnswer = new FinalReviewResultAnswerDropdown(4L);
-		FinalReviewResultAnswerHexStat hexstatAnswer = new FinalReviewResultAnswerHexStat(5L);
+		FinalReviewResultAnswerSubject subjectAnswer = new FinalReviewResultAnswerSubject(1L, 1L);
+		FinalReviewResultAnswerObjects objectAnswer = new FinalReviewResultAnswerObjects(1L, 2L);
+		FinalReviewResultAnswerRating ratingAnswer = new FinalReviewResultAnswerRating(1L, 3L);
+		FinalReviewResultAnswerDropdown dropdownAnswer = new FinalReviewResultAnswerDropdown(1L, 4L);
+		FinalReviewResultAnswerHexStat hexstatAnswer = new FinalReviewResultAnswerHexStat(1L, 5L);
 
 		List<FinalReviewResultAnswerSubject> subjectAnswers = List.of(subjectAnswer);
 		List<FinalReviewResultAnswerObjects> objectAnswers = List.of(objectAnswer);


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 최종 리뷰 결과 생성시 이미 생성된 데이터가 있음에도 불구하고 중복으로 데이터가 들어가는 것을 방지하는 로직을 추가했습니다
- 최종 결과 답변은 모두에게 공통적으로 보여지는 부분이 아니라 특정 사람에게만 보여지는 항목이라고 생각해 식별을 위한 userId를 추가했습니다.

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 주관식 최종 답변이 update되는 api는 다음 PR에 추가적으로 올리겠습니다!

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 최종_리뷰_중복생성_방지
