### PR TITLE
[REV-312] 주관식 답변 결과 업데이트 기능 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
 
 	NOT_FOUND_QUESTION_OPTION(NOT_FOUND, "존재하지 않는 질문 옵션입니다."),
 	NOT_FOUND_FINAL_REVIEW_RESULT(NOT_FOUND, "존재하지 않는 최종 리뷰 결과입니다."),
+	NOT_FOUND_FINAL_REVIEW_ANSWER_OF_SUBJECT(NOT_FOUND, "존재하지 않는 주관식 답변입니다."),
 	NOT_FOUND_PARTICIPANTS(NOT_FOUND, "참여 목록이 존재하지 않습니다."),
 
 	// 409 error

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/api/FinalReviewResultController.java
@@ -12,6 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -29,6 +30,7 @@ import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListRes
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewAnswerResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewResultResponse;
 import com.devcourse.ReviewRanger.auth.domain.UserPrincipal;
+import com.devcourse.ReviewRanger.finalReviewResult.dto.UpdateAnswerOfSubject;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -95,6 +97,21 @@ public class FinalReviewResultController {
 			= finalReviewResultService.createFinalReviewResult(finalReviewRequest);
 
 		return RangerResponse.ok(finalReviewResponse);
+	}
+
+	@Tag(name = "final-result")
+	@Operation(summary = "주관식 답변 업데이트", description = "전송 전 최종 리뷰 결과의 주관식 답변 업데이트 API", responses = {
+		@ApiResponse(responseCode = "200", description = "주관식 답변 업데이트 성공"),
+		@ApiResponse(responseCode = "404", description = "유효하지 않은 식별 값인 경우"),
+	})
+	@PatchMapping
+	@ResponseStatus(OK)
+	public RangerResponse<Void> updateFinalReviewAnswerOfSubject(
+		@RequestBody @Valid UpdateAnswerOfSubject updateAnswerOfSubject
+	) {
+		finalReviewResultService.updateAnswerOfSubject(updateAnswerOfSubject);
+
+		return RangerResponse.noData();
 	}
 
 	@Tag(name = "final-result")

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -32,6 +32,7 @@ import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReviewRespons
 import com.devcourse.ReviewRanger.finalReviewResult.dto.FinalReviewResultListResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewAnswerResponse;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewResultResponse;
+import com.devcourse.ReviewRanger.finalReviewResult.dto.UpdateAnswerOfSubject;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.DropdownTypeRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.FinalReviewResultRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.HexstatTypeRepository;
@@ -164,6 +165,21 @@ public class FinalReviewResultService {
 		}
 
 		return new CreateFinalReviewResponse(userId);
+	}
+
+	@Transactional
+	public void updateAnswerOfSubject(UpdateAnswerOfSubject updateAnswerOfSubject) {
+		validateReviewId(updateAnswerOfSubject.reviewId());
+
+		Long questionId = updateAnswerOfSubject.questionId();
+		Long userId = updateAnswerOfSubject.userId();
+
+		FinalReviewResultAnswerSubject subjectAnswer =
+			subjectTypeRepository.findByQuestionIdAndUserId(questionId, userId)
+				.orElseThrow(() -> new RangerException(NOT_FOUND_FINAL_REVIEW_ANSWER_OF_SUBJECT));
+
+		String updateSubject = updateAnswerOfSubject.answer();
+		subjectAnswer.update(updateSubject);
 	}
 
 	public CheckFinalResultStatus checkFinalResultStatus(Long reviewId) {

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerSubject.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/domain/FinalReviewResultAnswerSubject.java
@@ -24,4 +24,8 @@ public class FinalReviewResultAnswerSubject extends FinalReviewResultAnswer {
 	public void addAnswer(Object answer) {
 		this.subjects = String.valueOf(answer);
 	}
+
+	public void update(String updateSubject) {
+		this.subjects = updateSubject;
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/UpdateAnswerOfSubject.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/dto/UpdateAnswerOfSubject.java
@@ -1,0 +1,26 @@
+package com.devcourse.ReviewRanger.finalReviewResult.dto;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "주관식 리뷰 결과 업데이트 요청 DTO")
+public record UpdateAnswerOfSubject(
+	@Schema(description = "수신자 id")
+	@NotNull(message = "리뷰 대상 id는 빈값 일 수 없습니다.")
+	Long userId,
+
+	@Schema(description = "리뷰 id")
+	@NotNull(message = "리뷰 id는 빈값 일 수 없습니다.")
+	Long reviewId,
+
+	@Schema(description = "질문 id")
+	@NotNull(message = "질문 id는 빈값 일 수 없습니다.")
+	Long questionId,
+
+	@Schema(description = "정제된 주관식 답변 결과")
+	@NotBlank(message = "정제된 주관식 답변 결과는 빈값 일 수 없습니다")
+	String answer
+) {
+}

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/SubjectTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/SubjectTypeRepository.java
@@ -1,6 +1,7 @@
 package com.devcourse.ReviewRanger.finalReviewResult.repository;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -8,4 +9,6 @@ import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnsw
 
 public interface SubjectTypeRepository extends JpaRepository<FinalReviewResultAnswerSubject, Long> {
 	List<FinalReviewResultAnswerSubject> findAllByQuestionId(Long questionId);
+
+	Optional<FinalReviewResultAnswerSubject> findByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
@@ -41,6 +41,7 @@ import com.devcourse.ReviewRanger.finalReviewResult.domain.Hexstat;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReplyRequest;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.CreateFinalReviewRequest;
 import com.devcourse.ReviewRanger.finalReviewResult.dto.GetFinalReviewAnswerResponse;
+import com.devcourse.ReviewRanger.finalReviewResult.dto.UpdateAnswerOfSubject;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.DropdownTypeRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.FinalReviewResultRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.repository.HexstatTypeRepository;
@@ -239,6 +240,24 @@ class FinalReviewResultServiceTest {
 		verify(userRepository, times(1)).findById(any());
 		verify(reviewRepository, times(1)).findById(any());
 		verify(finalReviewResultRepository, times(0)).save(any(FinalReviewResult.class));
+	}
+
+	@Test
+	void 주관식_결과_업데이트_성공() {
+		// given
+		FinalReviewResultAnswerSubject answerSubject = new FinalReviewResultAnswerSubject(1L, 1L);
+		String updateAnswer = "주관식 답변을 정제한 내용입니다. 이것을 다시 저장할게요!!";
+		UpdateAnswerOfSubject updateAnswerOfSubject = new UpdateAnswerOfSubject(1L, 1L, 1L, updateAnswer);
+		Review mockReview = mock(Review.class);
+
+		when(reviewRepository.findById(anyLong())).thenReturn(Optional.ofNullable(mockReview));
+		when(subjectTypeRepository.findByQuestionIdAndUserId(1L, 1L)).thenReturn(Optional.of(answerSubject));
+
+		// when
+		finalReviewResultService.updateAnswerOfSubject(updateAnswerOfSubject);
+
+		// then
+		assertEquals(answerSubject.getSubjects(), updateAnswer);
 	}
 
 	@Test


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 최종 결과를 저장할 때 정제된 주관식 응답을 업데이트하는 기능을 추가했습니다.
- 아래 사진에서 저장버튼을 누를 때 동작하는 api입니다.
![image](https://github.com/prgrms-web-devcourse/Team-12-ReviewRanger-BE/assets/89267864/d4ddd7e0-47c6-4b2d-89ee-ab1802362fa6)
- 요청은 아래와 같이 옵니다.
```json
{
    "userId": 1,
    "reviewId": 1,
    "questionId": 1,
    "answer": "주관식 답변을 정제한 내용입니다. 이것을 다시 저장할게요!!"
}
```

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 누구를 대상으로 한 답변인지 식별이 필요하므로 userId를 통해 답변을 식별합니다.

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 주관식_결과_업데이트_성공: mockito로 `updateAnswerOfSubject`에 대한 단위 테스트를 진행했습니다.
