### PR TITLE
[REV-322] 최종 리뷰 결과의 QNA 조회 로직 변경

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultService.java
@@ -250,6 +250,7 @@ public class FinalReviewResultService {
 
 	public List<GetFinalReviewAnswerResponse> getFinalReviewAnswerList(Long finalReviewId) {
 		FinalReviewResult finalReviewResult = getFinalReviewResultOrThrow(finalReviewId);
+		Long userId = finalReviewResult.getUserId();
 		List<FinalQuestion> questions = finalReviewResult.getQuestions();
 
 		// 질문들의 식별자를 하나씩 사용하여 질문 타입에 맞는 답변들을 가져온다
@@ -264,17 +265,16 @@ public class FinalReviewResultService {
 
 			switch (finalQuestionType) {
 				case SUBJECTIVE -> {
-					List<FinalReviewResultAnswerSubject> subjectAnswers
-						= subjectTypeRepository.findAllByQuestionId(questionId); // TODO: 현재 조회하는 userID로 식별 필요
+					FinalReviewResultAnswerSubject subjectAnswers
+						= subjectTypeRepository.findByQuestionIdAndUserId(questionId, userId)
+						.orElseThrow(() -> new RangerException(NOT_FOUND_FINAL_REVIEW_ANSWER_OF_SUBJECT));
 
-					for (FinalReviewResultAnswerSubject answer : subjectAnswers) {
-						answerIdList.add(answer.getId());
-						answers.add(answer.getSubjects());
-					}
+					answerIdList.add(subjectAnswers.getId());
+					answers.add(subjectAnswers);
 				}
 				case SINGLE_CHOICE, MULTIPLE_CHOICE -> {
 					List<FinalReviewResultAnswerObjects> objectAnswers
-						= objectTypeRepository.findAllByQuestionId(questionId);
+						= objectTypeRepository.findAllByQuestionIdAndUserId(questionId, userId);
 
 					for (FinalReviewResultAnswerObjects answer : objectAnswers) {
 						answerIdList.add(answer.getId());
@@ -283,7 +283,7 @@ public class FinalReviewResultService {
 				}
 				case RATING -> {
 					List<FinalReviewResultAnswerRating> ratingAnswers
-						= ratingTypeRepository.findAllByQuestionId(questionId);
+						= ratingTypeRepository.findAllByQuestionIdAndUserId(questionId, userId);
 
 					for (FinalReviewResultAnswerRating answer : ratingAnswers) {
 						answerIdList.add(answer.getId());
@@ -292,7 +292,7 @@ public class FinalReviewResultService {
 				}
 				case DROPDOWN -> {
 					List<FinalReviewResultAnswerDropdown> dropdownAnswers
-						= dropdownTypeRepository.findAllByQuestionId(questionId);
+						= dropdownTypeRepository.findAllByQuestionIdAndUserId(questionId, userId);
 
 					for (FinalReviewResultAnswerDropdown answer : dropdownAnswers) {
 						answerIdList.add(answer.getId());
@@ -301,7 +301,7 @@ public class FinalReviewResultService {
 				}
 				case HEXASTAT -> {
 					List<FinalReviewResultAnswerHexStat> hexstatAnswers
-						= hexstatTypeRepository.findAllByQuestionId(questionId);
+						= hexstatTypeRepository.findAllByQuestionIdAndUserId(questionId, userId);
 
 					for (FinalReviewResultAnswerHexStat answer : hexstatAnswers) {
 						answerIdList.add(answer.getId());

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/DropdownTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/DropdownTypeRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnswerDropdown;
 
 public interface DropdownTypeRepository extends JpaRepository<FinalReviewResultAnswerDropdown, Long> {
-	List<FinalReviewResultAnswerDropdown> findAllByQuestionId(Long questionId);
+	List<FinalReviewResultAnswerDropdown> findAllByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/HexstatTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/HexstatTypeRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnswerHexStat;
 
 public interface HexstatTypeRepository extends JpaRepository<FinalReviewResultAnswerHexStat, Long> {
-	List<FinalReviewResultAnswerHexStat> findAllByQuestionId(Long questionId);
+	List<FinalReviewResultAnswerHexStat> findAllByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/ObjectTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/ObjectTypeRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnswerObjects;
 
 public interface ObjectTypeRepository extends JpaRepository<FinalReviewResultAnswerObjects, Long> {
-	List<FinalReviewResultAnswerObjects> findAllByQuestionId(Long questionId);
+	List<FinalReviewResultAnswerObjects> findAllByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/RatingTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/RatingTypeRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnswerRating;
 
 public interface RatingTypeRepository extends JpaRepository<FinalReviewResultAnswerRating, Long> {
-	List<FinalReviewResultAnswerRating> findAllByQuestionId(Long questionId);
+	List<FinalReviewResultAnswerRating> findAllByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/SubjectTypeRepository.java
+++ b/src/main/java/com/devcourse/ReviewRanger/finalReviewResult/repository/SubjectTypeRepository.java
@@ -1,6 +1,5 @@
 package com.devcourse.ReviewRanger.finalReviewResult.repository;
 
-import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -8,7 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import com.devcourse.ReviewRanger.finalReviewResult.domain.FinalReviewResultAnswerSubject;
 
 public interface SubjectTypeRepository extends JpaRepository<FinalReviewResultAnswerSubject, Long> {
-	List<FinalReviewResultAnswerSubject> findAllByQuestionId(Long questionId);
-
 	Optional<FinalReviewResultAnswerSubject> findByQuestionIdAndUserId(Long questionId, Long userId);
 }

--- a/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/finalReviewResult/application/FinalReviewResultServiceTest.java
@@ -338,18 +338,17 @@ class FinalReviewResultServiceTest {
 		FinalReviewResultAnswerDropdown dropdownAnswer = new FinalReviewResultAnswerDropdown(1L, 4L);
 		FinalReviewResultAnswerHexStat hexstatAnswer = new FinalReviewResultAnswerHexStat(1L, 5L);
 
-		List<FinalReviewResultAnswerSubject> subjectAnswers = List.of(subjectAnswer);
 		List<FinalReviewResultAnswerObjects> objectAnswers = List.of(objectAnswer);
 		List<FinalReviewResultAnswerRating> ratingAnswers = List.of(ratingAnswer);
 		List<FinalReviewResultAnswerDropdown> dropdownAnswers = List.of(dropdownAnswer);
 		List<FinalReviewResultAnswerHexStat> hexstatAnswers = List.of(hexstatAnswer);
 
 		when(finalReviewResultRepository.findById(finalReviewId)).thenReturn(Optional.of(fakeFinalReviewResult));
-		when(subjectTypeRepository.findAllByQuestionId(any())).thenReturn(subjectAnswers);
-		when(objectTypeRepository.findAllByQuestionId(any())).thenReturn(objectAnswers);
-		when(ratingTypeRepository.findAllByQuestionId(any())).thenReturn(ratingAnswers);
-		when(dropdownTypeRepository.findAllByQuestionId(any())).thenReturn(dropdownAnswers);
-		when(hexstatTypeRepository.findAllByQuestionId(any())).thenReturn(hexstatAnswers);
+		when(subjectTypeRepository.findByQuestionIdAndUserId(any(), any())).thenReturn(Optional.of(subjectAnswer));
+		when(objectTypeRepository.findAllByQuestionIdAndUserId(any(), any())).thenReturn(objectAnswers);
+		when(ratingTypeRepository.findAllByQuestionIdAndUserId(any(), any())).thenReturn(ratingAnswers);
+		when(dropdownTypeRepository.findAllByQuestionIdAndUserId(any(), any())).thenReturn(dropdownAnswers);
+		when(hexstatTypeRepository.findAllByQuestionIdAndUserId(any(), any())).thenReturn(hexstatAnswers);
 
 		// when
 		List<GetFinalReviewAnswerResponse> getFinalReviewAnswerResponses = finalReviewResultService.getFinalReviewAnswerList(


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 최종 리뷰 결과의 QNA 내용을 조회하는 로직에 userId를 추가했습니다
- 해당하는 user에 대한 답변을 식별해야 할 필요가 있다고 생각이 들어 추가하게 되었습니다

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 주관식은 한 사람당 한 개만 가지고 있으므로 List가 아닌 단일 객체로 반환받도록 수정하였습니다!!

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 최종_리뷰_결과_답변_상세조회_성공
