### PR TITLE
[REV-298] 리뷰 마감시 리뷰 전체 응답여부 검증 로직 추가

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
+++ b/src/main/java/com/devcourse/ReviewRanger/common/exception/ErrorCode.java
@@ -25,6 +25,7 @@ public enum ErrorCode {
 	FAIL_USER_LOGIN(NOT_FOUND, "존재하지 않는 계정입니다."),
 	NOT_FOUND_USER(NOT_FOUND, "존재하지 않는 사용자입니다."),
 	NOT_FOUND_REVIEW(NOT_FOUND, "존재하지 않는 리뷰입니다."),
+
 	NOT_FOUND_QUESTION(NOT_FOUND, "존재하지 않는 질문입니다."),
 	NOT_FOUND_PARTICIPATION(NOT_FOUND, "해당하는 리뷰가 없습니다."),
 	NOT_FOUND_REVIEW_TARGET(NOT_FOUND, "존재하지 않는 리뷰 대상입니다."),
@@ -34,6 +35,7 @@ public enum ErrorCode {
 	NOT_FOUND_QUESTION_OPTION(NOT_FOUND, "존재하지 않는 질문 옵션입니다."),
 	NOT_FOUND_FINAL_REVIEW_RESULT(NOT_FOUND, "존재하지 않는 최종 리뷰 결과입니다."),
 	NOT_FOUND_PARTICIPANTS(NOT_FOUND, "참여 목록이 존재하지 않습니다."),
+	NOT_FINISHED_PARTICIPANTS(NOT_FOUND, "리뷰가 모두 제출되지 않았습니다."),
 
 	// 409 error
 	EXIST_SAME_NAME(CONFLICT, "이미 사용중인 이름 입니다."),

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -99,7 +99,14 @@ public class ParticipationService {
 	@Transactional
 	public void closeParticipationOrThrow(Long reviewId) {
 		List<Participation> participations = getAllByReviewId(reviewId);
-		participations.stream().forEach(participation -> participation.changeStatus(ReviewStatus.DEADLINE));
+
+		participations.stream()
+			.peek(participation -> {
+				if (!participation.getIsAnswered()) {
+					throw new RangerException(NOT_FINISHED_PARTICIPANTS);
+				}
+			})
+			.forEach(participation -> participation.changeStatus(ReviewStatus.DEADLINE));
 	}
 
 	public List<ParticipationResponse> getAllParticipationOrThrow(Long reviewId, String name, String sort) {

--- a/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/participation/application/ParticipationService.java
@@ -101,12 +101,12 @@ public class ParticipationService {
 		List<Participation> participations = getAllByReviewId(reviewId);
 
 		participations.stream()
-			.peek(participation -> {
+			.forEach(participation -> {
 				if (!participation.getIsAnswered()) {
 					throw new RangerException(NOT_FINISHED_PARTICIPANTS);
 				}
-			})
-			.forEach(participation -> participation.changeStatus(ReviewStatus.DEADLINE));
+				participation.changeStatus(ReviewStatus.DEADLINE);
+			});
 	}
 
 	public List<ParticipationResponse> getAllParticipationOrThrow(Long reviewId, String name, String sort) {

--- a/src/test/java/com/devcourse/ReviewRanger/participation/application/ParticipationServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/participation/application/ParticipationServiceTest.java
@@ -197,7 +197,9 @@ class ParticipationServiceTest {
 	void 참여_마감_성공(){
 		// given
 		Long reviewId = 1L;
-		List<Participation> mockParticipations = List.of(new Participation(SUYEON_FIXTURE.toEntity()));
+		Participation participation = new Participation(SUYEON_FIXTURE.toEntity());
+		participation.answeredReview();
+		List<Participation> mockParticipations = List.of(participation);
 
 		when(participationRepository.findByReviewId(reviewId)).thenReturn(mockParticipations);
 
@@ -205,10 +207,26 @@ class ParticipationServiceTest {
 		participationService.closeParticipationOrThrow(reviewId);
 
 		// then
-		for (Participation participation : mockParticipations) {
-			assertEquals(ReviewStatus.END, participation.getReviewStatus());
+		for (Participation mockParticipation : mockParticipations) {
+			assertEquals(DEADLINE, participation.getReviewStatus());
 		}
 
 		verify(participationRepository, times(1)).findByReviewId(reviewId);
+	}
+
+	@Test
+	void 리뷰미응답에_따른_참여_마감_실패(){
+		// given
+		Long reviewId = 1L;
+		Participation participation = new Participation(SUYEON_FIXTURE.toEntity());
+		List<Participation> mockParticipations = List.of(participation);
+
+		when(participationRepository.findByReviewId(reviewId)).thenReturn(mockParticipations);
+
+		// when
+		// then
+		Assertions.assertThatThrownBy(() -> participationService.closeParticipationOrThrow(reviewId))
+			.isInstanceOf(RangerException.class)
+			.hasMessage(NOT_FINISHED_PARTICIPANTS.getMessage());
 	}
 }

--- a/src/test/java/com/devcourse/ReviewRanger/review/application/ReviewServiceSelectTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/review/application/ReviewServiceSelectTest.java
@@ -125,7 +125,7 @@ public class ReviewServiceSelectTest {
 		reviewService.closeReviewOrThrow(reviewId);
 
 		// then
-		assertEquals(ReviewStatus.END, mockReview.getStatus());
+		assertEquals(DEADLINE, mockReview.getStatus());
 		verify(reviewRepository, times(1)).findById(reviewId);
 		verify(participationService, times(1)).closeParticipationOrThrow(reviewId);
 	}


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 리뷰 마감시 해당 리뷰의 응답자들이 모두 재출했는지 여부 검증로직 추가 

### 🥺 TO REVIEWER  <!-- 추가적으로 하고싶은 말을 남겨주세요. -->
- 테스트 코드 및 api테스트 모두 완료했습니다.

### ✅ TEST <!-- 내가 작성한 테스트코드 작성 -->
- 리뷰 마감 기능이지만 전체 검증은 참여 서비스에서 발생함으로 참여 서비스에서 검증 로직에 대한 테스트를 진행했습니다.
