### PR TITLE
[REV-355] 요청에 따라 빈 답변값 반환 유무 분리 로직 구현

### DIFF
--- a/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetService.java
@@ -4,6 +4,8 @@ import static com.devcourse.ReviewRanger.common.exception.ErrorCode.*;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,7 @@ import com.devcourse.ReviewRanger.question.domain.QuestionOption;
 import com.devcourse.ReviewRanger.question.dto.response.GetQuestionOptionResponse;
 import com.devcourse.ReviewRanger.question.repository.QuestionOptionRepository;
 import com.devcourse.ReviewRanger.reply.application.ReplyService;
+import com.devcourse.ReviewRanger.reply.domain.Reply;
 import com.devcourse.ReviewRanger.reply.dto.response.ReplyResponse;
 import com.devcourse.ReviewRanger.user.domain.User;
 import com.devcourse.ReviewRanger.user.repository.UserRepository;
@@ -68,26 +71,30 @@ public class ReplyTargetService {
 
 	public List<ReplyTargetResponse> getAllRepliesByResponser(Long reviewId, Long responserId) {
 		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReviewIdAndResponserId(reviewId, responserId);
-		List<ReplyTargetResponse> responses = getAllRepliesByReviewedTargets(replyTargets);
 
-		return responses;
+		return getAllRepliesByTargets(replyTargets, this::getAllReplies);
 	}
 
-	public List<ReplyTargetResponse> getAllRepliesByReceiver(Long reviewId, Long receiverId) {
+	public List<ReplyTargetResponse> getAllNonEmptyRepliesByResponser(Long reviewId, Long responserId) {
+		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReviewIdAndResponserId(reviewId, responserId);
+
+		return getAllRepliesByTargets(replyTargets, this::getAllNonEmptyReplies);
+	}
+
+	public List<ReplyTargetResponse> getAllNonEmptyRepliesByReceiver(Long reviewId, Long receiverId) {
 		List<ReplyTarget> replyTargets = replyTargetRepository.findAllByReviewIdAndReceiverId(reviewId, receiverId);
-		List<ReplyTargetResponse> responses = getAllRepliesByReviewedTargets(replyTargets);
 
-		return responses;
+		return getAllRepliesByTargets(replyTargets, this::getAllNonEmptyReplies);
 	}
 
-	private List<ReplyTargetResponse> getAllRepliesByReviewedTargets(List<ReplyTarget> replyTargets) {
+	private List<ReplyTargetResponse> getAllRepliesByTargets(List<ReplyTarget> replyTargets,
+		Function<ReplyTarget, List<ReplyResponse>> replyResponseFunction) {
+
 		List<ReplyTargetResponse> responses = new ArrayList<>();
 
 		for (ReplyTarget replyTarget : replyTargets) {
 			ReplyTargetResponse replyTargetResponse = ReplyTargetResponse.toResponse(replyTarget);
-
-			List<ReplyResponse> replyResponses = getAllReplies(replyTarget);
-
+			List<ReplyResponse> replyResponses = replyResponseFunction.apply(replyTarget);
 			replyTargetResponse.addRepliesResponse(replyResponses);
 			responses.add(replyTargetResponse);
 		}
@@ -97,28 +104,31 @@ public class ReplyTargetService {
 
 	private List<ReplyResponse> getAllReplies(ReplyTarget replyTarget) {
 		return replyTarget.getReplies().stream()
-			.map(reply -> {
-				if (reply.isNotOptionQuestionReply()) {
-					return ReplyResponse.toResponse(reply);
-				}
-
-				QuestionOption questionOption = questionOptionRepository.findById(reply.getQuestionOptionId())
-					.orElseThrow(() -> new RangerException(NOT_FOUND_QUESTION_OPTION));
-				GetQuestionOptionResponse questionOptionResponse = GetQuestionOptionResponse.toResponse(
-					questionOption);
-
-				return ReplyResponse.toResponse(reply, questionOptionResponse);
-			})
+			.map(this::mapToMultipleReply)
 			.toList();
 	}
 
-	public ReplyTarget getByIdOrThrow(Long id) {
-		return replyTargetRepository.findById(id)
-			.orElseThrow(() -> new RangerException(NOT_FOUND_REVIEW_TARGET));
+	private List<ReplyResponse> getAllNonEmptyReplies(ReplyTarget replyTarget) {
+		return replyTarget.getReplies().stream()
+			.filter(Predicate.not(Reply::isEmptyAnswer))
+			.map(this::mapToMultipleReply)
+			.toList();
 	}
 
-	public List<ReplyTarget> getAllByParticipationId(Long participationId) {
-		return replyTargetRepository.findAllByParticipationId(participationId);
+	private ReplyResponse mapToMultipleReply(Reply reply) {
+		if (reply.isNotOptionQuestionReply()) {
+			return ReplyResponse.toResponse(reply);
+		}
+
+		QuestionOption questionOption = getQuestionOption(reply.getQuestionOptionId());
+		GetQuestionOptionResponse questionOptionResponse = GetQuestionOptionResponse.toResponse(
+			questionOption);
+
+		return ReplyResponse.toResponse(reply, questionOptionResponse);
 	}
 
+	private QuestionOption getQuestionOption(Long questionOptionId) {
+		return questionOptionRepository.findById(questionOptionId)
+			.orElseThrow(() -> new RangerException(NOT_FOUND_QUESTION_OPTION));
+	}
 }

--- a/src/main/java/com/devcourse/ReviewRanger/ReviewRangerApplication.java
+++ b/src/main/java/com/devcourse/ReviewRanger/ReviewRangerApplication.java
@@ -9,13 +9,7 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 @EnableJpaAuditing
 @EnableWebSecurity
 @EnableAsync
-@SpringBootApplication(
-	exclude = {
-		org.springframework.cloud.aws.autoconfigure.context.ContextInstanceDataAutoConfiguration.class,
-		org.springframework.cloud.aws.autoconfigure.context.ContextStackAutoConfiguration.class,
-		org.springframework.cloud.aws.autoconfigure.context.ContextRegionProviderAutoConfiguration.class
-	}
-)
+@SpringBootApplication
 public class ReviewRangerApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/devcourse/ReviewRanger/reply/domain/Reply.java
+++ b/src/main/java/com/devcourse/ReviewRanger/reply/domain/Reply.java
@@ -85,7 +85,7 @@ public class Reply extends BaseEntity {
 		return this.questionOptionId == null || this.questionOptionId == 0;
 	}
 
-	private boolean isEmptyAnswer() {
+	public boolean isEmptyAnswer() {
 		return isEmpty(this.answerText) || isEmpty(this.questionOptionId) || isEmpty(this.rating) || isEmpty(
 			this.hexastat);
 	}

--- a/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
+++ b/src/main/java/com/devcourse/ReviewRanger/review/api/ReviewController.java
@@ -114,7 +114,6 @@ public class ReviewController {
 		return RangerResponse.ok(response);
 	}
 
-
 	@Tag(name = "review")
 	@Operation(summary = "[토큰] 응답자를 제외한 리뷰의 수신자 전체 조회", description = "[토큰] 응답자를 제외한 리뷰의 수신자 전체 조회 API", responses = {
 		@ApiResponse(responseCode = "200", description = "응답자를 제외한 리뷰의 수신자 전체 조회")
@@ -219,7 +218,7 @@ public class ReviewController {
 		@PathVariable Long reviewId,
 		@PathVariable Long responserId) {
 		reviewService.checkReviewOwnerEqualityOrThrow(reviewId, user.getId());
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByResponser(
+		List<ReplyTargetResponse> responses = replyTargetService.getAllNonEmptyRepliesByResponser(
 			reviewId, responserId);
 
 		return RangerResponse.ok(responses);
@@ -237,7 +236,7 @@ public class ReviewController {
 		@PathVariable Long reviewId,
 		@PathVariable Long receiverId) {
 		reviewService.checkReviewOwnerEqualityOrThrow(reviewId, user.getId());
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(reviewId, receiverId);
+		List<ReplyTargetResponse> responses = replyTargetService.getAllNonEmptyRepliesByReceiver(reviewId, receiverId);
 
 		return RangerResponse.ok(responses);
 	}

--- a/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetServiceTest.java
+++ b/src/test/java/com/devcourse/ReviewRanger/ReplyTarget/application/ReplyTargetServiceTest.java
@@ -84,7 +84,7 @@ class ReplyTargetServiceTest {
 		given(questionOptionRepository.findById(1L)).willReturn(Optional.of(questionOption));
 
 		//when
-		List<ReplyTargetResponse> responses = replyTargetService.getAllRepliesByReceiver(1L, 2L);
+		List<ReplyTargetResponse> responses = replyTargetService.getAllNonEmptyRepliesByReceiver(1L, 2L);
 
 		//then
 		assertThat(responses.get(0).responser().name()).isEqualTo("장수연");


### PR DESCRIPTION
### 👍 PR DESCRIPTION<!-- PR 내용을 간단하게 작성해주세요. 작업을 의미하는지 확인해주세요. -->
- 프론트에서 필수가 아닌 질문에 답변에 대한 GET API가 다르게 구현되어 있어 빈 답변 값의 반환 유무에 따라 로직을 분리하였습니다.

### 상황
- 응답자가 답변을 한 경우 응답자가 자신의 답변을 수정하기 위해 자신의 답변을 GET 요청시
  - 필수가 아닌 질문에 답변에 디폴트 값을 넣어서 반환해줍니다.
- 리뷰 생성자가 응답자의 답변을 GET 요청시
  - 필수가 아닌 질문에 답변을 포함하지 않고 반환합니다.
